### PR TITLE
Add page for explaining `data/voices/all.json`

### DIFF
--- a/api-reference/data/voices.mdx
+++ b/api-reference/data/voices.mdx
@@ -1,0 +1,33 @@
+---
+title: 'List All Voices'
+api: 'GET https://users.rime.ai/data/voices/all.json'
+---
+
+## View In Browser
+
+https://users.rime.ai/data/voices/all.json
+
+## Example structure
+
+```json
+{
+  "v1": [
+    "agnes",
+    "alexa",
+    "alonzo"
+    // ...and more...
+  ],
+  "mist": [
+    "amber",
+    "ana",
+    "antoine"
+    // ...and more ...
+  ]
+}
+```
+
+## Explanation
+
+The response object is keyed by the applicable `modelId`. This is the same `modelId` used as an argument to our [TTS APIs](http://localhost:3000/api-reference/endpoint/streaming-pcm).
+
+For example: if calling the TTS API with `modelId` of `"v1"`, `"agnes"` is a valid `speaker`, but `"amber"` wouldn't be.

--- a/mint.json
+++ b/mint.json
@@ -60,6 +60,12 @@
         "api-reference/endpoint/json-wav",
         "api-reference/endpoint/json-ogg"
       ]
+    },
+    {
+      "group": "API Metadata",
+      "pages": [
+        "api-reference/data/voices"
+      ]
     }
   ],
   "api": {


### PR DESCRIPTION
This adds a group (API Metadata) and a single page that explains the `data/voices/all.json` resource, links to it, and shares a sample structure of it.