### PR TITLE
Arcana release

### DIFF
--- a/api-reference/arcana/streaming-mp3.mdx
+++ b/api-reference/arcana/streaming-mp3.mdx
@@ -22,15 +22,15 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="repetition_penalty" type="float" default="1.5">
-  The repetition penalty.
+  The repetition penalty. Range is 1 to 2.
 </ParamField>
 
 <ParamField body="temperature" type="float" default="0.5">
-  The temperature.
+  The temperature. Range is 0 to 1.
 </ParamField>
 
-<ParamField body="top_p" type="float" default="0.95">
-  The top p.
+<ParamField body="top_p" type="float" default="0.5">
+  The top p. Range is 0 to 1.
 </ParamField>
 
 <ParamField body="max_tokens" type="int" default="1200">
@@ -50,7 +50,7 @@ curl --request POST \
   "modelId": "arcana",
   "repetition_penalty": 1.5,
   "temperature": 0.5,
-  "top_p": 0.95,
+  "top_p": 0.5,
   "max_tokens": 1200,
 }'
 ```
@@ -66,7 +66,7 @@ payload = {
     "modelId": "arcana",
     "repetition_penalty": 1.5,
     "temperature": 0.5,
-    "top_p": 0.95,
+    "top_p": 0.5,
     "max_tokens": 1200,
 }
 headers = {
@@ -98,7 +98,7 @@ const options = {
     Authorization: 'Bearer <authorization>',
     'Content-Type': 'application/json'
   },
-  body: '{"speaker":"<string>","text":"<string>","modelId":"arcana","repetition_penalty":1.5,"temperature":0.5,"top_p":0.95,"max_tokens":1200}'
+  body: '{"speaker":"<string>","text":"<string>","modelId":"arcana","repetition_penalty":1.5,"temperature":0.5,"top_p":0.5,"max_tokens":1200}'
 };
 
 fetch('https://users.rime.ai/v1/rime-tts', options)
@@ -120,7 +120,7 @@ curl_setopt_array($curl, [
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
-  CURLOPT_POSTFIELDS => "{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.95,\n  \"max_tokens\": 1200\n}",
+  CURLOPT_POSTFIELDS => "{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.5,\n  \"max_tokens\": 1200\n}",
   CURLOPT_HTTPHEADER => [
     "Accept: audio/mp3",
     "Authorization: Bearer <authorization>",
@@ -154,7 +154,7 @@ func main() {
 
   url := "https://users.rime.ai/v1/rime-tts"
 
-  payload := strings.NewReader("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.95,\n  \"max_tokens\": 1200\n}")
+  payload := strings.NewReader("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.5,\n  \"max_tokens\": 1200\n}")
 
   req, _ := http.NewRequest("POST", url, payload)
 
@@ -178,7 +178,7 @@ HttpResponse<String> response = Unirest.post("https://users.rime.ai/v1/rime-tts"
   .header("Accept", "audio/mp3")
   .header("Authorization", "Bearer <authorization>")
   .header("Content-Type", "application/json")
-  .body("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.95,\n  \"max_tokens\": 1200\n}")
+  .body("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.5,\n  \"max_tokens\": 1200\n}")
   .asString();
 ```
 </RequestExample>

--- a/api-reference/arcana/streaming-mp3.mdx
+++ b/api-reference/arcana/streaming-mp3.mdx
@@ -18,7 +18,7 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `arcana` for hyper-realistic conversational voices.
+  Choose `arcana` for Rime's most realistic conversational voices.
 </ParamField>
 
 <ParamField body="repetition_penalty" type="float" default="1.5">

--- a/api-reference/arcana/streaming-mp3.mdx
+++ b/api-reference/arcana/streaming-mp3.mdx
@@ -1,0 +1,172 @@
+---
+title: 'Streaming MP3'
+api: 'POST https://users.rime.ai/v1/rime-tts'
+authMethod: "bearer"
+---
+
+## Fixed Headers
+
+<ParamField header="Accept" type="audio/mp3" required></ParamField>
+
+## Variable Parameters
+
+<ParamField body="speaker" type="string" required>
+  Must be one of the Arcana voices <a href="https://docs.rime.ai/api-reference/voices">listed in our documentation</a>.
+</ParamField>
+<ParamField body="text" type="string" required>
+  The text you'd like spoken. Character limit per request is 500 via the API and 1,000 in the dashboard UI.
+</ParamField>
+
+<ParamField body="modelId" type="string">
+  Choose `arcana` for hyper-realistic conversational voices.
+</ParamField>
+
+<ParamField body="repetition_penalty" type="float" default="1.5">
+  The repetition penalty.
+</ParamField>
+
+<ParamField body="temperature" type="float" default="0.5">
+  The temperature.
+</ParamField>
+
+<RequestExample>
+```bash cURL
+curl --request POST \
+  --url https://users.rime.ai/v1/rime-tts \
+  --header 'Accept: audio/mp3' \
+  --header 'Authorization: Bearer <authorization>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "speaker": "<string>",
+  "text": "<string>",
+  "modelId": "arcana",
+  "repetition_penalty": 1.5,
+  "temperature": 0.5,
+}'
+```
+
+```python Python
+import requests
+
+url = "https://users.rime.ai/v1/rime-tts"
+
+payload = {
+    "speaker": "<string>",
+    "text": "<string>",
+    "modelId": "arcana",
+    "repetition_penalty": 1.5,
+    "temperature": 0.5,
+}
+headers = {
+    "Accept": "audio/mp3",
+    "Authorization": "Bearer <authorization>",
+    "Content-Type": "application/json"
+}
+
+# Use stream=True to handle streaming response
+response = requests.request("POST", url, json=payload, headers=headers, stream=True)
+
+# Check if the request was successful
+if response.status_code == 200:
+    with open("audio_output.mp3", "wb") as f:
+        for chunk in response.iter_content(chunk_size=1024):
+            if chunk:
+                f.write(chunk)
+else:
+    print("Error:", response.status_code)
+
+print(response.text)
+```
+
+```javascript JavaScript
+const options = {
+  method: 'POST',
+  headers: {
+    Accept: 'audio/mp3',
+    Authorization: 'Bearer <authorization>',
+    'Content-Type': 'application/json'
+  },
+  body: '{"speaker":"<string>","text":"<string>","modelId":"arcana>","repetition_penalty":1.5,"temperature":0.5}'
+};
+
+fetch('https://users.rime.ai/v1/rime-tts', options)
+  .then(response => response.text())
+  .then(response => console.log(response))
+  .catch(err => console.error(err));
+```
+
+```php PHP
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, [
+  CURLOPT_URL => "https://users.rime.ai/v1/rime-tts",
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => "",
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 30,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => "POST",
+  CURLOPT_POSTFIELDS => "{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5\n}",
+  CURLOPT_HTTPHEADER => [
+    "Accept: audio/mp3",
+    "Authorization: Bearer <authorization>",
+    "Content-Type: application/json"
+  ],
+]);
+
+$response = curl_exec($curl);
+$err = curl_error($curl);
+
+curl_close($curl);
+
+if ($err) {
+  echo "cURL Error #:" . $err;
+} else {
+  echo $response;
+}
+```
+
+```go Go
+package main
+
+import (
+  "fmt"
+  "strings"
+  "net/http"
+  "io/ioutil"
+)
+
+func main() {
+
+  url := "https://users.rime.ai/v1/rime-tts"
+
+  payload := strings.NewReader("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5\n}")
+
+  req, _ := http.NewRequest("POST", url, payload)
+
+  req.Header.Add("Accept", "audio/mp3")
+  req.Header.Add("Authorization", "Bearer <authorization>")
+  req.Header.Add("Content-Type", "application/json")
+
+  res, _ := http.DefaultClient.Do(req)
+
+  defer res.Body.Close()
+  body, _ := ioutil.ReadAll(res.Body)
+
+  fmt.Println(res)
+  fmt.Println(string(body))
+
+}
+```
+
+```java Java
+HttpResponse<String> response = Unirest.post("https://users.rime.ai/v1/rime-tts")
+  .header("Accept", "audio/mp3")
+  .header("Authorization", "Bearer <authorization>")
+  .header("Content-Type", "application/json")
+  .body("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5\n}")
+  .asString();
+```
+</RequestExample>

--- a/api-reference/arcana/streaming-mp3.mdx
+++ b/api-reference/arcana/streaming-mp3.mdx
@@ -29,6 +29,14 @@ authMethod: "bearer"
   The temperature.
 </ParamField>
 
+<ParamField body="top_p" type="float" default="0.95">
+  The top p.
+</ParamField>
+
+<ParamField body="max_tokens" type="int" default="1200">
+  The max tokens. Range is 200 to 5000.
+</ParamField>
+
 <RequestExample>
 ```bash cURL
 curl --request POST \
@@ -42,6 +50,8 @@ curl --request POST \
   "modelId": "arcana",
   "repetition_penalty": 1.5,
   "temperature": 0.5,
+  "top_p": 0.95,
+  "max_tokens": 1200,
 }'
 ```
 
@@ -56,6 +66,8 @@ payload = {
     "modelId": "arcana",
     "repetition_penalty": 1.5,
     "temperature": 0.5,
+    "top_p": 0.95,
+    "max_tokens": 1200,
 }
 headers = {
     "Accept": "audio/mp3",
@@ -86,7 +98,7 @@ const options = {
     Authorization: 'Bearer <authorization>',
     'Content-Type': 'application/json'
   },
-  body: '{"speaker":"<string>","text":"<string>","modelId":"arcana>","repetition_penalty":1.5,"temperature":0.5}'
+  body: '{"speaker":"<string>","text":"<string>","modelId":"arcana","repetition_penalty":1.5,"temperature":0.5,"top_p":0.95,"max_tokens":1200}'
 };
 
 fetch('https://users.rime.ai/v1/rime-tts', options)
@@ -108,7 +120,7 @@ curl_setopt_array($curl, [
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
-  CURLOPT_POSTFIELDS => "{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5\n}",
+  CURLOPT_POSTFIELDS => "{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.95,\n  \"max_tokens\": 1200\n}",
   CURLOPT_HTTPHEADER => [
     "Accept: audio/mp3",
     "Authorization: Bearer <authorization>",
@@ -142,7 +154,7 @@ func main() {
 
   url := "https://users.rime.ai/v1/rime-tts"
 
-  payload := strings.NewReader("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5\n}")
+  payload := strings.NewReader("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.95,\n  \"max_tokens\": 1200\n}")
 
   req, _ := http.NewRequest("POST", url, payload)
 
@@ -166,7 +178,7 @@ HttpResponse<String> response = Unirest.post("https://users.rime.ai/v1/rime-tts"
   .header("Accept", "audio/mp3")
   .header("Authorization", "Bearer <authorization>")
   .header("Content-Type", "application/json")
-  .body("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5\n}")
+  .body("{\n  \"speaker\": \"<string>\",\n  \"text\": \"<string>\",\n  \"modelId\": \"arcana\",\n  \"temperature\": 0.5,\n  \"repetition_penalty\": 1.5,\n  \"top_p\": 0.95,\n  \"max_tokens\": 1200\n}")
   .asString();
 ```
 </RequestExample>

--- a/api-reference/changelog.mdx
+++ b/api-reference/changelog.mdx
@@ -5,7 +5,7 @@ icon: list
 
 ## Rime API Changelog
 
-<Update label="2025-04-23">
+<Update label="2025-04-24">
  * We’ve launched **Arcana** — a new model for expressive, natural voice synthesis. Available now with `modelId: arcana`.
 </Update>
 

--- a/api-reference/changelog.mdx
+++ b/api-reference/changelog.mdx
@@ -4,12 +4,19 @@ icon: list
 ---
 
 ## Rime API Changelog
+
+<Update label="2025-04-23">
+ * We’ve launched **Arcana** — a new model for expressive, natural voice synthesis. Available now with `modelId: arcana`.
+</Update>
+
 <Update label="2025-03-28">
- * The 'lang' ID 'spa-mx' has been added. Using this accesses the same spanish languages but uses 'pesos' instead of 'dolares' for currency. 
- * New 'lang: fra' has been added. We now have French voices available on the dashboard and via API.
+ * The `lang` ID `spa-mx` has been added. Using this accesses the same spanish languages but uses `pesos` instead of `dolares` for currency. 
+ * New `lang: fra` has been added. We now have French voices available on the dashboard and via API.
+</Update>
+
 <Update label="2025-03-26">
   * The `spell()` function now works for Spanish. Try it out! "El nombre se escribe spell(Isabella)."
-  * Fixed a bug where silence information is not processed properly when pauseBetweenBracket is True
+  * Fixed a bug where silence information is not processed properly when `pauseBetweenBrackets` is True
   * The url `demo-api.rime.ai` has been **deprecated**. Please use `demo.rime.ai` instead if you are using the demo API.
 </Update>
 

--- a/api-reference/data/voices-v2.mdx
+++ b/api-reference/data/voices-v2.mdx
@@ -29,6 +29,13 @@ https://users.rime.ai/data/voices/all-v2.json
       "mari",
       // ...and more ...
     ]
+  },
+  "arcana": {
+    "eng": [
+      "luna",
+      "celeste",
+      // ...and more...
+    ]
   }
 }
 ```

--- a/api-reference/data/voices-v2.mdx
+++ b/api-reference/data/voices-v2.mdx
@@ -31,7 +31,7 @@ https://users.rime.ai/data/voices/all-v2.json
     ]
   },
   "arcana": {
-    "eng": [
+    "any": [
       "luna",
       "celeste",
       // ...and more...

--- a/api-reference/endpoint/json-mp3.mdx
+++ b/api-reference/endpoint/json-mp3.mdx
@@ -19,7 +19,7 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="lang" type="string" default="eng">

--- a/api-reference/endpoint/json-mulaw.mdx
+++ b/api-reference/endpoint/json-mulaw.mdx
@@ -19,7 +19,7 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="lang" type="string" default="eng">

--- a/api-reference/endpoint/json-ogg.mdx
+++ b/api-reference/endpoint/json-ogg.mdx
@@ -42,7 +42,7 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="speedAlpha" type="float" default="1.0">

--- a/api-reference/endpoint/json-wav.mdx
+++ b/api-reference/endpoint/json-wav.mdx
@@ -23,7 +23,7 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="pauseBetweenBrackets" type="bool" default="false">

--- a/api-reference/endpoint/sse.mdx
+++ b/api-reference/endpoint/sse.mdx
@@ -19,7 +19,7 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mist` for hyper-realistic conversational voices or `v1` for Rime's first-gen model (default: `v1`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="audioFormat" type="string">

--- a/api-reference/endpoint/streaming-mp3.mdx
+++ b/api-reference/endpoint/streaming-mp3.mdx
@@ -18,7 +18,7 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="lang" type="string" default="eng">

--- a/api-reference/endpoint/streaming-mulaw.mdx
+++ b/api-reference/endpoint/streaming-mulaw.mdx
@@ -39,7 +39,7 @@ Streaming MULAW returns headerless files.
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="speedAlpha" type="float" default="1.0">

--- a/api-reference/endpoint/streaming-pcm.mdx
+++ b/api-reference/endpoint/streaming-pcm.mdx
@@ -18,7 +18,7 @@ authMethod: "bearer"
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="lang" type="string" default="eng">

--- a/api-reference/endpoint/websockets-json.mdx
+++ b/api-reference/endpoint/websockets-json.mdx
@@ -114,7 +114,7 @@ type ErrorEvent = {
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="audioFormat" type="string">

--- a/api-reference/endpoint/websockets.mdx
+++ b/api-reference/endpoint/websockets.mdx
@@ -53,7 +53,7 @@ This forces whatever buffer exists, if any, to be synthesized, and for the serve
 </ParamField>
 
 <ParamField body="modelId" type="string">
-  Choose `mistv2` for hyper-realistic conversational voices or `mist` for Rime's prior model (default: `mist`)
+  Choose `mistv2` for Rime's fastest, most accurate, and most customizable model, or `mist` for Rime's earlier model (default: `mist`)
 </ParamField>
 
 <ParamField body="audioFormat" type="string">

--- a/api-reference/models.mdx
+++ b/api-reference/models.mdx
@@ -5,7 +5,7 @@ icon: cube
 
 Models are constantly being trained and finetuned based on user and customer feedback. Please check back often as we push changes frequently.
 
-There are currently two models that Rime has in production, `mistv2` and `mist`.
+There are currently 3 models that Rime has in production, `arcana`, `mistv2` and `mist`.
 
 **Model v1 was released in April 2022 and has been deprecated.**
 
@@ -18,3 +18,11 @@ There are currently two models that Rime has in production, `mistv2` and `mist`.
 * Advanced pronunciation control
 * Ultra-fast on-prem latency of ~70ms, perfect for real-time applications
 * More accents, demographics, and speaking styles
+
+**Arcana**, released April 2025, is Rime’s most expressive and lifelike TTS model to date. It pushes the boundary of naturalness and emotional depth in synthesized speech.
+
+* Highly expressive, natural-sounding speech with emotional nuance  
+* Fine-grained control over prosody, pacing, and tone  
+* Supports a wide range of vocal demographics, including different ages, accents, and cultural backgrounds  
+* Enhanced realism for dynamic, conversational, and character-driven use cases  
+* Available via `modelId: arcana` through Rime’s API endpoints

--- a/api-reference/models.mdx
+++ b/api-reference/models.mdx
@@ -7,9 +7,13 @@ Models are constantly being trained and finetuned based on user and customer fee
 
 There are currently 3 models that Rime has in production, `arcana`, `mistv2` and `mist`.
 
-**Model v1 was released in April 2022 and has been deprecated.**
+**Arcana**, released April 2025, is Rime’s most expressive and lifelike TTS model to date. It pushes the boundary of naturalness and emotional depth in synthesized speech.
 
-**Mist** is Rime’s next generation TTS engine, released April 2023, capable of synthesizing conversational speech. Using the `modelId` parameter for Rime’s TTS endpoints, specifying `mistv2` or `mist`, will allow you to synthesize speech using this newer family of models. As of February 2025, the default value for `modelId` when unspecified is `mist`.
+* Highly expressive, natural-sounding speech with emotional nuance  
+* Fine-grained control over prosody, pacing, and tone  
+* Supports a wide range of vocal demographics, including different ages, accents, and cultural backgrounds  
+* Enhanced realism for dynamic, conversational, and character-driven use cases  
+* Available via `modelId: arcana` through Rime’s API endpoints
 
 **Mistv2**, released February 2025 has the following features:
 
@@ -19,10 +23,7 @@ There are currently 3 models that Rime has in production, `arcana`, `mistv2` and
 * Ultra-fast on-prem latency of ~70ms, perfect for real-time applications
 * More accents, demographics, and speaking styles
 
-**Arcana**, released April 2025, is Rime’s most expressive and lifelike TTS model to date. It pushes the boundary of naturalness and emotional depth in synthesized speech.
+**Mist** is Rime’s next generation TTS engine, released April 2023, capable of synthesizing conversational speech. Using the `modelId` parameter for Rime’s TTS endpoints, specifying `mistv2` or `mist`, will allow you to synthesize speech using this newer family of models. As of February 2025, the default value for `modelId` when unspecified is `mist`.
 
-* Highly expressive, natural-sounding speech with emotional nuance  
-* Fine-grained control over prosody, pacing, and tone  
-* Supports a wide range of vocal demographics, including different ages, accents, and cultural backgrounds  
-* Enhanced realism for dynamic, conversational, and character-driven use cases  
-* Available via `modelId: arcana` through Rime’s API endpoints
+**Model v1 was released in April 2022 and has been deprecated.**
+

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -15,11 +15,9 @@ Rime provides speech synthesis technologies that perfectly balance quality, cust
 
 Rime has two flagship models:
 - **Arcana**: Unmatched Realism
-    - Arcana offers ultra-realistic voices that capture the full richness of human speech, from subtle rhythms and natural warmth to the tiny imperfections that make each voice unique. Perfect for creative and business use cases that need the authenticity of real conversation.
 - **Mist v2**: Speed and Customizability
-    - Built for high-volume, business-critical applications, Mist v2 delivers unmatched accuracy and customization at scale. Our fastest and most precise voices help you convert prospects, retain customers, and drive sales by ensuring your message resonates exactly as intended.
 
-We still offer support for the older **Mist** model as well.
+We still offer support for the older **Mist** model as well. See the [Models](/api-reference/models) page for more details.
 
 ## Getting Started
 

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -11,12 +11,22 @@ Rime provides speech synthesis technologies that perfectly balance quality, cust
 - Customize the performance of the speech that's synthesized using linguistically-aware markup.
 - Synthesize speech at sub-200 millisecond speeds.
 
+## Models
+
+Rime has two flagship models:
+- **Arcana**: Unmatched Realism
+    - Arcana offers ultra-realistic voices that capture the full richness of human speech, from subtle rhythms and natural warmth to the tiny imperfections that make each voice unique. Perfect for creative and business use cases that need the authenticity of real conversation.
+- **Mist v2**: Speed and Customizability
+    - Built for high-volume, business-critical applications, Mist v2 delivers unmatched accuracy and customization at scale. Our fastest and most precise voices help you convert prospects, retain customers, and drive sales by ensuring your message resonates exactly as intended.
+
+We still offer support for the older **Mist** model as well.
+
 ## Getting Started
 
-Every user gets 50,000 characters free every month. To kick off your exploration:
-- [Sign up](https://rime.ai/signup) or [sign in](https://rime.ai/login) to your Rime account using Google or Github OAuth.
-- Generate an [API Key](https://rime.ai/dashboard/tokens)
-- Check out your [Dashboard](https://rime.ai/dashboard) to start generating lifelike speech with Rime.
+Every user gets a generous amount of free characters every month. To kick off your exploration:
+- [Sign up](https://app.rime.ai/signup/) or [sign in](https://app.rime.ai/login/) to your Rime account using Google or Github OAuth.
+- Generate an [API Key](https://app.rime.ai/tokens/)
+- Check out your [Dashboard](https://app.rime.ai/) to start generating lifelike speech with Rime.
 
 ## How to use the API
 

--- a/mint.json
+++ b/mint.json
@@ -82,29 +82,40 @@
       ]
     },
     {
-      "group": "Streaming API reference",
+      "group": "Arcana API reference",
       "pages": [
-        "api-reference/endpoint/streaming-pcm",
-        "api-reference/endpoint/streaming-mp3",
-        "api-reference/endpoint/streaming-mulaw",
-        "api-reference/endpoint/sse"
+        "api-reference/arcana/streaming-mp3"
       ]
     },
     {
-      "group": "Websocket API reference",
-      "pages": [
-        "api-reference/endpoint/websockets",
-        "api-reference/endpoint/websockets-json"
-      ]
-    },
-    {
-      "group": "Non-Streaming API reference",
-      "pages": [
-        "api-reference/endpoint/json-mp3",
-        "api-reference/endpoint/json-wav",
-        "api-reference/endpoint/json-ogg",
-        "api-reference/endpoint/json-mulaw"
-      ]
+    "group": "Mist v2 API reference",
+    "pages": [
+      {
+        "group": "Streaming",
+        "pages": [
+          "api-reference/endpoint/streaming-pcm",
+          "api-reference/endpoint/streaming-mp3",
+          "api-reference/endpoint/streaming-mulaw",
+          "api-reference/endpoint/sse"
+        ]
+      },
+      {
+        "group": "Websocket",
+        "pages": [
+          "api-reference/endpoint/websockets",
+          "api-reference/endpoint/websockets-json"
+        ]
+      },
+      {
+        "group": "Non-Streaming",
+        "pages": [
+          "api-reference/endpoint/json-mp3",
+          "api-reference/endpoint/json-wav",
+          "api-reference/endpoint/json-ogg",
+          "api-reference/endpoint/json-mulaw"
+        ]
+      }
+    ]
     },
     {
       "group": "API Metadata",

--- a/mint.json
+++ b/mint.json
@@ -47,7 +47,7 @@
           ]
         },
         {
-          "group": "Customizing Speech",
+          "group": "Customizing Mist v2",
           "icon": "wrench",
           "pages": [
             "api-reference/linguistics",


### PR DESCRIPTION
## Changes

- Changelog
- Models
  - Note: a few sentences used single quotes ' instead of backticks \` to format inline code (e.g., 'lang' instead of `lang`). This caused some code blocks to render incorrectly in Markdown/MDX. 
- List All Voices