### PR TITLE
Document the done server event for /ws3

### DIFF
--- a/api-reference/arcana/websockets-json.mdx
+++ b/api-reference/arcana/websockets-json.mdx
@@ -116,6 +116,19 @@ type TimestampsEvent = {
 }
 ```
 
+#### Done
+
+After the last audio chunk for a synthesis batch has been sent, the server emits a `done` event. This signals that the current synthesis is fully complete. If the client sends more text and triggers further synthesis, another `done` will follow.
+
+```typescript
+type DoneEvent = {
+  type: "done",
+  contextId: string | null,
+}
+```
+
+When exactly `done` fires depends on the `segment` setting. See [Segmentation & Behavior Settings](/docs/websockets-segment) for full details.
+
 #### Error
 
 In the event of a malformed or unexpected input, the server will immediately respond with an error message.

--- a/api-reference/mistv3/websockets-json.mdx
+++ b/api-reference/mistv3/websockets-json.mdx
@@ -99,6 +99,19 @@ type TimestampsEvent = {
 }
 ```
 
+#### Done
+
+After the last audio chunk for a synthesis batch has been sent, the server emits a `done` event. This signals that the current synthesis is fully complete. If the client sends more text and triggers further synthesis, another `done` will follow.
+
+```typescript
+type DoneEvent = {
+  type: "done",
+  contextId: string | null,
+}
+```
+
+When exactly `done` fires depends on the `segment` setting. See [Segmentation & Behavior Settings](/docs/websockets-segment) for full details.
+
 #### Error
 
 In the event of a malformed or unexpected input, the server will immediately respond with an error message. The server will _not_ close the connection, and will still accept subsequent well-formed messages.

--- a/docs/websockets-segment.mdx
+++ b/docs/websockets-segment.mdx
@@ -66,6 +66,7 @@ Once flushed, Rime synthesizes the entire accumulated buffer as a single utteran
 - Synthesizing audio whenever a `flush` is received.
 - Queuing the buffer for synthesis if the previous utterance is still being produced.
 - Never synthesizing mid-stream without your explicit instruction.
+- Sending a `done` event after all audio for each `flush` has been delivered. Each `flush` produces exactly one `done`. `eos` also emits `done` for any content remaining in the buffer.
 
 ### Example
 
@@ -136,6 +137,7 @@ Rime watches the incoming token stream for sentence-ending punctuation: `.`, `?`
 - Accumulating tokens until a sentence boundary is detected.
 - Synthesizing the buffer at that boundary, **only if no audio is currently being produced**.
 - Using heuristics to determine whether a given punctuation mark constitutes a sentence end.
+- Sending a `done` event once per synthesis run, after the last segment has been delivered and the text buffer is empty. Intermediate sentence boundaries within a run do **not** emit `done`.
 
 ### When to use this
 
@@ -201,6 +203,7 @@ Each time Rime receives a text message and the synthesis pipeline is idle, it sy
 
 - Synthesizing immediately upon receiving text when the pipeline is idle.
 - Accumulating tokens while synthesis is active, then synthesizing the full buffer once idle again.
+- Sending a `done` event once per synthesis run, after the last segment has been delivered and the buffer is empty.
 
 ### When to use this
 

--- a/docs/websockets.mdx
+++ b/docs/websockets.mdx
@@ -135,11 +135,32 @@ Discards the accumulated text buffer without synthesizing it. Useful when the us
 
 ### `eos` (end of stream)
 
-Synthesizes whatever remains in the buffer, then immediately closes the connection.
+Synthesizes whatever remains in the buffer, sends a `done` event, then immediately closes the connection.
 
 ```json
 { "operation": "eos" }
 ```
+
+---
+
+## Synthesis completion (`done`)
+
+After all audio for a synthesis batch has been sent, the server emits a `done` event. This is the signal that the current utterance is fully delivered. If the client triggers further synthesis, another `done` will follow.
+
+```typescript
+type DoneEvent = {
+  type: "done",
+  contextId: string | null,
+}
+```
+
+`done` fires at different points depending on the `segment` setting:
+
+- **`segment=never`** — fires once per `flush`, after all audio for that flush has been sent. `eos` also fires `done` for any content remaining in the buffer.
+- **`segment=bySentence` / `segment=immediate`** — fires once per synthesis run, after the last segment completes and the buffer is empty. Intermediate sentence boundaries do not emit `done`.
+- **`eos` (all modes)** — always emits `done` before closing the connection.
+
+See [Segmentation & Behavior Settings](/docs/websockets-segment) for details on each mode.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `done` to the Receive events section of `api-reference/mistv3/websockets-json.mdx` with its TypeScript type
- Adds a `## Synthesis completion (done)` section to `docs/websockets.mdx` with a per-`segment` breakdown of when it fires
- Adds `done` behavior bullet to each segment mode's "What Rime is responsible for" list in `docs/websockets-segment.mdx`
- Updates the `eos` description to note it sends `done` before closing

These are now guaranteed by this PR: https://github.com/rimelabs/rime-supabase/pull/532

## Test plan

- [ ] Review `done` semantics match actual server behavior (`segment=never`: once per flush; `segment=bySentence`/`immediate`: once per synthesis run when buffer empty; `eos`: always before close)
- [ ] Check links to `/docs/websockets-segment` resolve correctly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)