### PR TITLE
[onprem] Document RIME_API_KEY, API_KEY_HEADER, and PLATFORM_API_KEY

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -7,6 +7,14 @@ icon: list
 
 <Tip>Subscribe to the [RSS feed](https://docs.rime.ai/docs/changelog/rss.xml) to get notified of new releases.</Tip>
 
+<Update label="2026-04-24">
+* API on-prem image `20260424`:
+  * New environment variables for authentication configuration:
+    * `RIME_API_KEY`: pre-configure the API key at the deployment level so callers don't need to include it in each request. Can also be mounted as a secret file at `/secrets/rime_api_key`.
+    * `API_KEY_HEADER`: specify an alternate header name for platforms that intercept the `Authorization` header.
+    * `PLATFORM_API_KEY`: supply a platform API key for authenticated inter-container requests. Can also be mounted as a secret file at `/secrets/platform_api_key`.
+</Update>
+
 <Update label="2026-04-20">
 * Arcana V2, Arcana V3 and Mist V3 release `20260420`.
 * General performance improvements and bug fixes.
@@ -19,7 +27,6 @@ icon: list
 * Mist v3 release `20260404`:
   * Reached general availability.
 * General performance improvements across the inference stack for all models.
-</Update>
 
 <Update label="2026-04-07">
 * API on-prem image `20260407`:

--- a/docs/on-prem/quickstart.mdx
+++ b/docs/on-prem/quickstart.mdx
@@ -165,7 +165,7 @@ The Mist v3 images can be found at `us-docker.pkg.dev/rime-labs/mist/v3/omni:<ta
 
 The latest image version is:
 
-* `us-docker.pkg.dev/rime-labs/api/service:20260407`
+* `us-docker.pkg.dev/rime-labs/api/service:20260424`
 
 ## Docker Compose configuration
 
@@ -258,6 +258,62 @@ ARCANA_ARA_MODEL_URL
 ```
 
 The API will route to these model backends based on the request parameter <a href="https://docs.rime.ai/api-reference/arcana/streaming-mp3#param-lang">lang</a>.
+
+### Authentication configuration
+
+By default, callers must pass their Rime API key in every request via the `Authorization: Bearer <key>` header. Two additional environment variables let you configure authentication at the deployment level instead.
+
+#### Pre-configuring the API key (`RIME_API_KEY`)
+
+If you set `RIME_API_KEY`, the API service will use it to authenticate with the Rime license server automatically, and callers do not need to include an API key in their requests.
+
+You can supply it as an environment variable:
+
+```yaml compose.yml
+environment:
+  - MODEL_URL=http://model:8080/invocations
+  - RIME_API_KEY=<your-rime-api-key>
+```
+
+Or mount it as a secret file at `/secrets/rime_api_key` inside the container:
+
+```yaml compose.yml
+services:
+  api:
+    image: us-docker.pkg.dev/rime-labs/api/service:<tag>
+    environment:
+      - MODEL_URL=http://model:8080/invocations
+    volumes:
+      - /run/secrets/rime_api_key:/secrets/rime_api_key:ro
+```
+
+When neither is provided, the per-request `Authorization` header pathway remains active as normal.
+
+#### Alternate API key header (`API_KEY_HEADER`)
+
+On platforms that intercept the `Authorization` header, set `API_KEY_HEADER` to the name of an alternate header that callers will use to pass their Rime API key:
+
+```yaml compose.yml
+environment:
+  - MODEL_URL=http://model:8080/invocations
+  - API_KEY_HEADER=x-my-platform-rime-api-key
+```
+
+Callers then authenticate with:
+
+```bash
+curl -H "x-my-platform-rime-api-key: <your-rime-api-key>" ...
+```
+
+#### Platform API key (`PLATFORM_API_KEY`)
+
+On platforms that require authenticated inter-container requests, set `PLATFORM_API_KEY` so the API service can reach the model backend. It can also be mounted as a secret at `/secrets/platform_api_key`:
+
+```yaml compose.yml
+environment:
+  - MODEL_URL=http://model:8080/invocations
+  - PLATFORM_API_KEY=<your-platform-api-key>
+```
 
 ### Start Docker Compose
 


### PR DESCRIPTION
## Summary

- Documents `RIME_API_KEY` — pre-configure the Rime API key at deployment time via env var or mounted secret at `/secrets/rime_api_key`, so callers don't need to pass an API key per-request
- Documents `API_KEY_HEADER` — for platforms like Baseten that intercept the `Authorization` header, allows specifying an alternate header name for the API key
- Documents `PLATFORM_API_KEY` — for platforms requiring authenticated inter-container requests to the model backend, also supports mounted secret at `/secrets/platform_api_key`

Related code changes: rimelabs/rime-supabase `matt/onprem/auth_and_healthcheck_refactor`