### PR TITLE
Remove Reo.dev analytics script

### DIFF
--- a/reo.js
+++ b/reo.js
@@ -1,1 +1,0 @@
-!function(){var e,t,n;e="06e8ac7044098eb",t=function(){Reo.init({clientID:"06e8ac7044098eb"})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.async=!0,n.onload=t,document.head.appendChild(n)}();


### PR DESCRIPTION
## Summary

- Delete `reo.js`. Mintlify auto-includes any `.js` file in the content root, so removing the file stops the Reo beacon from loading on docs.rime.ai.

## Test plan

- [ ] Mintlify preview build: no `reo.js` request in the network panel.
- [ ] After deploy: no requests to `static.reo.dev` from docs.rime.ai pages.

Closes ENG-1098.