### PR TITLE
Add Coda to CLI quickstart and CLI reference pages

### DIFF
--- a/cli-reference/reference.mdx
+++ b/cli-reference/reference.mdx
@@ -46,7 +46,7 @@ auth_header_prefix = "Api-Key"
 Select an environment with the `--env` flag:
 
 ```bash
-rime tts "Hello" -s astra -m arcana --env staging
+rime tts "Hello" -s astra -m coda --env staging
 ```
 
 **Resolution order:** Environment variables override config file values, which override defaults. Within the config file, named environment values override top-level values.
@@ -55,7 +55,7 @@ rime tts "Hello" -s astra -m arcana --env staging
 
 | Format | Extension | Default for | Notes |
 | ------ | --------- | ----------- | ----- |
-| WAV | `.wav` | `arcana`, `arcanav2`, `mistv3` | Uncompressed, higher quality, larger files |
+| WAV | `.wav` | `coda`, `arcana`, `arcanav2`, `mistv3` | Uncompressed, higher quality, larger files |
 | MP3 | `.mp3` | `mistv2`, `mist` | Compressed, smaller files. Default for `mistv2` and `mist` |
 
 ## Metadata embedding

--- a/cli-reference/rime-curl.mdx
+++ b/cli-reference/rime-curl.mdx
@@ -17,10 +17,10 @@ When providing text, `--speaker` and `--model-id` are required. When run without
 | Flag | Short | Default | Description |
 | ---- | ----- | ------- | ----------- |
 | `--speaker` | `-s` | `astra`* | Voice speaker to use |
-| `--model-id` | `-m` | `arcana`* | Model ID |
+| `--model-id` | `-m` | `coda`* | Model ID |
 | `--lang` | `-l` | `eng` | Language code |
 | `--speed-alpha` | -- | `1` | Speed multiplier — must be greater than 0 |
-| `--sampling-rate` | -- | -- | Output sampling rate in Hz. Arcana: `8000`, `16000`, `22050`, `24000`, `44100`, `48000`, `96000`. Mist: `4000`–`44100` |
+| `--sampling-rate` | -- | -- | Output sampling rate in Hz. Coda/Arcana: `8000`, `16000`, `22050`, `24000`, `44100`, `48000`, `96000`. Mist: `4000`–`44100` |
 | `--oneline` | -- | `false` | Output as a single line for easy copy-paste |
 | `--api-url` | -- | -- | API URL override |
 
@@ -59,8 +59,8 @@ These flags are only supported by `mist` and `mistv2`. They are not supported by
 rime curl
 
 # Generate curl for custom text
-rime curl "Hello from Rime" -s celeste -m arcana
+rime curl "Hello from Rime" -s celeste -m coda
 
 # Single-line output
-rime curl "Hello" -s astra -m arcana --oneline
+rime curl "Hello" -s astra -m coda --oneline
 ```

--- a/cli-reference/rime-hello-play.mdx
+++ b/cli-reference/rime-hello-play.mdx
@@ -6,7 +6,7 @@ icon: "play"
 
 ## `rime hello`
 
-Quick demo that generates a time-appropriate greeting ("good morning/afternoon/evening from Rime AI!") using the Astra voice on the Arcana model.
+Quick demo that generates a time-appropriate greeting ("good morning/afternoon/evening from Rime AI!") using the Astra voice on the Coda model.
 
 ```bash
 rime hello

--- a/cli-reference/rime-monitoring.mdx
+++ b/cli-reference/rime-monitoring.mdx
@@ -16,7 +16,7 @@ rime speedtest
 
 | Flag | Short | Default | Description |
 | ---- | ----- | ------- | ----------- |
-| `--model` | `-m` | `arcana` | Model ID for the test request |
+| `--model` | `-m` | `coda` | Model ID for the test request |
 | `--runs` | -- | `1` | Number of requests per endpoint — reports mean/min/max when greater than 1 |
 | `--timeout` | -- | `10s` | Per-request timeout (`0` disables timeout) |
 | `--url` | -- | -- | Additional URL to test, not in config (repeatable) |
@@ -61,7 +61,7 @@ When `--runs` is greater than 1, the JSON output includes `ttfb_min_ms` and `ttf
 
 ## `rime usage`
 
-Display daily character usage history for the past week, broken down by Mist and Arcana models.
+Display daily character usage history for the past week, broken down by Mist, Arcana, and Coda models.
 
 ```bash
 rime usage
@@ -78,10 +78,10 @@ Also supports the global `--json` flag.
 ### Example output
 
 ```
-       Day  Mist Chars  Arcana Chars       Total
-----------  ----------  ------------  ----------
-2026-02-24           0         1,234       1,234
-2026-02-23         500         2,100       2,600
+       Day  Mist Chars  Arcana Chars  Coda Chars       Total
+----------  ----------  ------------  ----------  ----------
+2026-05-19           0           500       3,400       3,900
+2026-05-18         500         2,100           0       2,600
 ```
 
 ---

--- a/cli-reference/rime-tts.mdx
+++ b/cli-reference/rime-tts.mdx
@@ -4,7 +4,7 @@ description: "Synthesize text to speech from the command line using the Rime CLI
 icon: "waveform"
 ---
 
-Synthesize text to speech. Supports WAV and MP3 formats. The format is automatically selected based on the model: `mist` and `mistv2` output MP3, while `mistv3`, `arcana`, and `arcanav2` default to WAV. Use `--format` to override.
+Synthesize text to speech. Supports WAV and MP3 formats. The format is automatically selected based on the model: `mist` and `mistv2` output MP3, while `coda`, `mistv3`, `arcana`, and `arcanav2` default to WAV. Use `--format` to override.
 
 ```bash
 rime tts TEXT --speaker VOICE --model-id MODEL
@@ -17,7 +17,7 @@ rime tts TEXT --speaker VOICE --model-id MODEL
 | Flag | Short | Description |
 | ---- | ----- | ----------- |
 | `--speaker` | `-s` | Voice speaker to use (e.g., `astra`, `celeste`, `orion`) |
-| `--model-id` | `-m` | Model ID: `arcana`, `arcanav2`, `mistv3`, `mistv2`, or `mist` |
+| `--model-id` | `-m` | Model ID: `coda`, `arcana`, `arcanav2`, `mistv3`, `mistv2`, or `mist` |
 
 ## Optional flags
 
@@ -27,8 +27,8 @@ rime tts TEXT --speaker VOICE --model-id MODEL
 | `--play` | `-p` | `false` | Play audio after synthesis (default behavior when no output is specified) |
 | `--lang` | `-l` | `eng` | Language code (e.g., `eng`, `es`, `fra`). Valid codes depend on model |
 | `--format` | `-f` | -- | Audio format: `wav` or `mp3` (overrides model default) |
-| `--speed-alpha` | -- | `1` | Speed multiplier. For `mist`/`mistv2`: lower is faster. For `mistv3`/`arcana`: higher is faster |
-| `--sampling-rate` | -- | -- | Output sampling rate in Hz. Arcana: `8000`, `16000`, `22050`, `24000`, `44100`, `48000`, `96000`. Mist: `4000`–`44100` |
+| `--speed-alpha` | -- | `1` | Speed multiplier. For `mist`/`mistv2`: lower is faster. For `coda`/`arcana`/`mistv3`: higher is faster |
+| `--sampling-rate` | -- | -- | Output sampling rate in Hz. Coda/Arcana: `8000`, `16000`, `22050`, `24000`, `44100`, `48000`, `96000`. Mist: `4000`–`44100` |
 | `--api-url` | -- | -- | API URL (default: `$RIME_API_URL` or `https://users.rime.ai/v1/rime-tts`) |
 
 ## Arcana/arcanav2 flags
@@ -61,13 +61,13 @@ These flags are supported by `mist` and `mistv2` only. They are not supported by
 
 ```bash
 # Play audio directly through speakers
-rime tts "Hello world" -s astra -m arcana
+rime tts "Hello world" -s astra -m coda
 
 # Save to a WAV file
-rime tts "Hello world" -s astra -m arcana -o output.wav
+rime tts "Hello world" -s astra -m coda -o output.wav
 
 # Pipe audio to stdout
-rime tts "Hello world" -s astra -m arcana -o - > audio.wav
+rime tts "Hello world" -s astra -m coda -o - > audio.wav
 
 # Use mistv3 (WAV by default)
 rime tts "Hello world" -s peak -m mistv3
@@ -75,20 +75,21 @@ rime tts "Hello world" -s peak -m mistv3
 # Use mistv2 (outputs MP3 by default)
 rime tts "Hello world" -s peak -m mistv2
 
-# Synthesize in Spanish with Arcana
-rime tts "Hola mundo" -s astra -m arcana -l es
+# Synthesize in Spanish with Coda
+rime tts "Hola mundo" -s astra -m coda -l es
 
 # JSON output with timing metadata
-rime tts "Hello world" -s astra -m arcana -o output.wav --json
+rime tts "Hello world" -s astra -m coda -o output.wav --json
 ```
 
 ## Supported languages by model
 
 | Model | Languages |
 | ----- | --------- |
+| `coda` | `eng`, `ara`, `fra`, `ger`, `jpn`, `por`, `spa` (and ISO 639-1 equivalents) |
 | `arcana` | `eng`, `ara`, `fra`, `ger`, `heb`, `hin`, `jpn`, `por`, `sin`, `spa`, `tam` (and ISO 639-1 equivalents) |
 | `arcanav2` | `eng`, `spa`, `ger`, `fra`, `hin` (and ISO 639-1 equivalents) |
 | `mistv3` | `eng`, `fra`, `ger`, `spa` (and ISO 639-1 equivalents) |
 | `mistv2` / `mist` | `eng`, `fra`, `ger`, `spa` (and ISO 639-1 equivalents) |
 
-<Note>The `mist` and `mistv2` models default to MP3. `mistv3`, `arcana`, and `arcanav2` default to WAV. Use `--format` to override.</Note>
+<Note>The `mist` and `mistv2` models default to MP3. `coda`, `mistv3`, `arcana`, and `arcanav2` default to WAV. Use `--format` to override.</Note>

--- a/cli-reference/troubleshooting.mdx
+++ b/cli-reference/troubleshooting.mdx
@@ -27,7 +27,7 @@ rime tts "Hello" -s cove -m mistv2 -f mp3
 ## No audio playback
 
 - Check your system audio output settings
-- Try saving to a file instead: `rime tts "Hello" -s astra -m arcana -o output.wav`
+- Try saving to a file instead: `rime tts "Hello" -s astra -m coda -o output.wav`
 - Headless builds (e.g., Docker) require `-o FILE` since playback is disabled
 
 ## "command not found: rime"

--- a/docs/quickstart-cli.mdx
+++ b/docs/quickstart-cli.mdx
@@ -54,7 +54,7 @@ rime hello
 Now that the CLI is set up, generate speech from any text:
 
 ```bash
-rime tts "Hello from Rime." -s celeste -m arcana
+rime tts "Hello from Rime." -s celeste -m coda
 ```
 
 ![Demo of the `rime tts` command](/images/cli/tts-demo.gif)
@@ -62,7 +62,7 @@ rime tts "Hello from Rime." -s celeste -m arcana
 This plays the audio directly. To save it to a file instead:
 
 ```bash
-rime tts "Hey, how's it going?" -s celeste -m arcana -o welcome.wav
+rime tts "Hey, how's it going?" -s celeste -m coda -o welcome.wav
 ```
 
 Play it back with waveform visualization:
@@ -78,20 +78,20 @@ rime play welcome.wav
 Rime offers 94+ voices. Swap the `--speaker` flag to change the voice:
 
 ```bash
-rime tts "The quick brown fox." -s orion -m arcana
-rime tts "The quick brown fox." -s luna -m arcana
+rime tts "The quick brown fox." -s orion -m coda
+rime tts "The quick brown fox." -s luna -m coda
 rime tts "The quick brown fox." -s peak -m mistv3
 rime tts "The quick brown fox." -s peak -m mistv2
 ```
 
-<Note>`mistv3`, `arcana`, and `arcanav2` output WAV by default. `mistv2` and `mist` output MP3 by default. Use `--format` to override.</Note>
+<Note>`coda`, `mistv3`, `arcana`, and `arcanav2` output WAV by default. `mistv2` and `mist` output MP3 by default. Use `--format` to override.</Note>
 
 ## Generate a curl command
 
 Need to integrate with the API directly? Generate a ready-to-use curl command:
 
 ```bash
-rime curl "Hello from Rime" -s astra -m arcana
+rime curl "Hello from Rime" -s astra -m coda
 ```
 
 ```
@@ -103,7 +103,7 @@ curl --request POST \
   --data '{
   "text": "Hello from Rime",
   "speaker": "astra",
-  "modelId": "arcana",
+  "modelId": "coda",
   "lang": "eng"
 }'
 # Tip: use --show-key or export RIME_CLI_API_KEY
@@ -121,7 +121,7 @@ Add `--show-key` to include your actual API key in the output, or `--oneline` fo
     Browse all 94+ available voices
   </Card>
   <Card title="Models" icon="microchip" href="/docs/models">
-    Compare models: Arcana, Mist v3, Mist v2
+    Compare models: Coda, Arcana, Mist v3, Mist v2
   </Card>
   <Card title="TTS in Five Minutes" icon="rocket" href="/docs/quickstart-five-minute">
     Use the API from Python or JavaScript


### PR DESCRIPTION
## Summary

Updates the CLI quickstart and CLI reference pages to use **Coda** as the default model in examples and flag values. Stacked on top of #221 (the main Coda launch docs PR) so the diff here shows only the CLI changes.

This PR is kept separate so it can be held back if the `rime` CLI binary itself isn't updated to accept `-m coda` by the 5/19 Coda launch — the docs PR can ship on time either way.

## Files changed

- `docs/quickstart-cli.mdx`
- `cli-reference/rime-tts.mdx`
- `cli-reference/rime-curl.mdx`
- `cli-reference/rime-monitoring.mdx`
- `cli-reference/rime-hello-play.mdx`
- `cli-reference/troubleshooting.mdx`
- `cli-reference/reference.mdx`

## What changed

### Examples and default flag values
- All `-m arcana` CLI invocations in code samples swapped to `-m coda`.
- `rime curl --model-id` default → `coda` (was `arcana`).
- `rime speedtest --model` default → `coda` (was `arcana`).
- `rime hello` description updated to say "on the Coda model".

### Tables and notes
- `rime tts` "Supported languages by model" — new Coda row at the top: `eng`, `ara`, `fra`, `ger`, `jpn`, `por`, `spa` (and ISO 639-1 equivalents).
- `--speed-alpha` direction note (`rime tts`) — Coda joins Arcana/Mist v3 on the higher-is-faster side.
- `--sampling-rate` notes (`rime tts`, `rime curl`) — regrouped as "Coda/Arcana" (same supported set).
- WAV-default notes/tables (`rime tts` top description and bottom Note, `cli-reference/reference.mdx` audio format table, `docs/quickstart-cli.mdx` Note) — Coda added alongside `mistv3`/`arcana`/`arcanav2`.
- Models card in the quickstart now reads "Coda, Arcana, Mist v3, Mist v2".
- `rime usage` description and example output — added Coda Chars column; description now lists Mist/Arcana/Coda.

### Intentionally preserved
- The `## Arcana/arcanav2 flags` sections in `rime-tts.mdx` and `rime-curl.mdx` (LLM controls: `--temperature`, `--top-p`, `--max-tokens`, `--repetition-penalty`) are kept Arcana-only — Coda does not expose those parameters.
- The existing `arcana` and `arcanav2` rows in the language table.

## Prerequisites for merge

- The `rime` CLI binary needs to accept `coda` as a value for `-m` / `--model-id`.
- The CLI output column "Coda Chars" in `rime usage` should match what the CLI actually prints after its update.

## Test plan

- [ ] After CLI update, run `rime tts "Hello world" -s astra -m coda` and confirm audio plays.
- [ ] Run `rime curl "Hello" -s astra -m coda --oneline` and confirm the generated curl works.
- [ ] Run `rime usage` and confirm the column header matches the docs (Mist / Arcana / Coda).
- [ ] Run `rime speedtest` with no flags and confirm the default `--model` is now `coda`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)