### PR TITLE
Add API reference and authentication landing pages plus missing-path redirects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -42,7 +42,8 @@
               "docs/regional-endpoints",
               "docs/quickstart-five-minute",
               "docs/quickstart-livekit",
-              "docs/quickstart-cli"
+              "docs/quickstart-cli",
+              "docs/api-authentication"
             ]
           },
           {
@@ -516,6 +517,291 @@
     {
       "source": "/api-reference/quickstart-python",
       "destination": "/docs/quickstart-five-minute"
+    },
+
+    {
+      "source": "/docs/quickstart",
+      "destination": "/docs/quickstart-five-minute"
+    },
+    {
+      "source": "/docs/api-quickstart",
+      "destination": "/docs/quickstart-five-minute"
+    },
+    {
+      "source": "/docs/tts-in-five-minutes",
+      "destination": "/docs/quickstart-five-minute"
+    },
+    {
+      "source": "/quickstart",
+      "destination": "/docs/quickstart-five-minute"
+    },
+    {
+      "source": "/quickstarts/five-minute-guide",
+      "destination": "/docs/quickstart-five-minute"
+    },
+    {
+      "source": "/core/quickstarts/five-minute-guide",
+      "destination": "/docs/quickstart-five-minute"
+    },
+    {
+      "source": "/docs/get-started",
+      "destination": "/docs/quickstart-five-minute"
+    },
+    {
+      "source": "/docs/getting-started",
+      "destination": "/docs/quickstart-five-minute"
+    },
+    {
+      "source": "/getting-started",
+      "destination": "/docs/quickstart-five-minute"
+    },
+
+    {
+      "source": "/reference/postrimetts",
+      "destination": "/api-reference/coda/http"
+    },
+    {
+      "source": "/reference/postrimetts-1",
+      "destination": "/api-reference/coda/http"
+    },
+    {
+      "source": "/reference/post_v1-rime-tts",
+      "destination": "/api-reference/coda/http"
+    },
+    {
+      "source": "/docs/rime-tts-http",
+      "destination": "/api-reference/coda/http"
+    },
+    {
+      "source": "/api/v1/rime-tts",
+      "destination": "/api-reference/coda/http"
+    },
+    {
+      "source": "/streaming-http",
+      "destination": "/api-reference/coda/http"
+    },
+    {
+      "source": "/http-streaming",
+      "destination": "/api-reference/coda/http"
+    },
+    {
+      "source": "/docs/streaming-http",
+      "destination": "/api-reference/coda/http"
+    },
+
+    {
+      "source": "/docs/oov",
+      "destination": "/api-reference/other/oov"
+    },
+    {
+      "source": "/api-reference/oov",
+      "destination": "/api-reference/other/oov"
+    },
+    {
+      "source": "/docs/utilities/coverage-checking",
+      "destination": "/api-reference/other/oov"
+    },
+
+    {
+      "source": "/api-reference/textnorm",
+      "destination": "/api-reference/other/textnorm"
+    },
+    {
+      "source": "/docs/utilities/text-normalization",
+      "destination": "/docs/text-normalization"
+    },
+    {
+      "source": "/docs/text-processing",
+      "destination": "/docs/text-normalization"
+    },
+
+    {
+      "source": "/docs/voice-selection",
+      "destination": "/docs/voices"
+    },
+    {
+      "source": "/features/voices",
+      "destination": "/docs/voices"
+    },
+
+    {
+      "source": "/features/models",
+      "destination": "/docs/models"
+    },
+    {
+      "source": "/mist-api",
+      "destination": "/docs/models"
+    },
+
+    {
+      "source": "/docs/websocket",
+      "destination": "/docs/websockets"
+    },
+    {
+      "source": "/docs/websocket-json",
+      "destination": "/docs/websockets"
+    },
+    {
+      "source": "/docs/streaming-websocket-json",
+      "destination": "/docs/websockets"
+    },
+    {
+      "source": "/reference/websockets-json",
+      "destination": "/docs/websockets"
+    },
+    {
+      "source": "/reference/websockets",
+      "destination": "/docs/websockets"
+    },
+    {
+      "source": "/docs/api-reference/websockets",
+      "destination": "/docs/websockets"
+    },
+
+    {
+      "source": "/docs/arcana/websockets",
+      "destination": "/api-reference/arcana/websockets"
+    },
+    {
+      "source": "/docs/arcana-websockets",
+      "destination": "/api-reference/arcana/websockets"
+    },
+    {
+      "source": "/reference/arcana-websockets",
+      "destination": "/api-reference/arcana/websockets"
+    },
+
+    {
+      "source": "/docs/mist-v3-websockets",
+      "destination": "/api-reference/mistv3/websockets"
+    },
+    {
+      "source": "/reference/mist-v3-websockets",
+      "destination": "/api-reference/mistv3/websockets"
+    },
+    {
+      "source": "/api/mist-v3/websockets",
+      "destination": "/api-reference/mistv3/websockets"
+    },
+
+    {
+      "source": "/docs/mist-v2-websockets",
+      "destination": "/api-reference/mistv2/websockets"
+    },
+    {
+      "source": "/reference/mist-v2-websockets",
+      "destination": "/api-reference/mistv2/websockets"
+    },
+
+    {
+      "source": "/docs/mist-websocket-json",
+      "destination": "/api-reference/mistv3/websockets-json"
+    },
+
+    {
+      "source": "/docs/arcana/streaming-http",
+      "destination": "/api-reference/arcana/http"
+    },
+    {
+      "source": "/arcana-api",
+      "destination": "/api-reference/arcana/http"
+    },
+
+    {
+      "source": "/api/mist-v3/streaming-http",
+      "destination": "/api-reference/mistv3/http"
+    },
+    {
+      "source": "/mist-v3",
+      "destination": "/api-reference/mistv3/http"
+    },
+    {
+      "source": "/v1/mist-v3",
+      "destination": "/api-reference/mistv3/http"
+    },
+    {
+      "source": "/api-reference/mist-v3",
+      "destination": "/api-reference/mistv3/http"
+    },
+    {
+      "source": "/api-reference/mist-v3/http",
+      "destination": "/api-reference/mistv3/http"
+    },
+    {
+      "source": "/docs/api-reference/mist-v3",
+      "destination": "/api-reference/mistv3/http"
+    },
+
+    {
+      "source": "/mist-v2-api",
+      "destination": "/api-reference/mistv2/http"
+    },
+    {
+      "source": "/api-reference/mist-v2",
+      "destination": "/api-reference/mistv2/http"
+    },
+    {
+      "source": "/api-reference/mist-v2/http",
+      "destination": "/api-reference/mistv2/http"
+    },
+
+    {
+      "source": "/api-reference/voices/all-v2",
+      "destination": "/api-reference/data/voices-v2"
+    },
+    {
+      "source": "/reference/data-voices-voice-details-json",
+      "destination": "/api-reference/data/voice-details"
+    },
+
+    {
+      "source": "/docs/api",
+      "destination": "/docs/api-reference"
+    },
+    {
+      "source": "/api",
+      "destination": "/docs/api-reference"
+    },
+    {
+      "source": "/reference",
+      "destination": "/docs/api-reference"
+    },
+    {
+      "source": "/reference/api",
+      "destination": "/docs/api-reference"
+    },
+    {
+      "source": "/docs/v1-api-reference",
+      "destination": "/docs/api-reference"
+    },
+    {
+      "source": "/docs/text-to-speech",
+      "destination": "/docs/api-reference"
+    },
+    {
+      "source": "/docs/rest",
+      "destination": "/docs/api-reference"
+    },
+    {
+      "source": "/docs/api-reference/utilities",
+      "destination": "/docs/api-reference"
+    },
+
+    {
+      "source": "/authentication",
+      "destination": "/docs/api-authentication"
+    },
+    {
+      "source": "/core/authentication",
+      "destination": "/docs/api-authentication"
+    },
+    {
+      "source": "/cli/authentication",
+      "destination": "/docs/api-authentication"
+    },
+    {
+      "source": "/reference/api-authentication",
+      "destination": "/docs/api-authentication"
     }
   ]
 }

--- a/docs.json
+++ b/docs.json
@@ -521,287 +521,354 @@
 
     {
       "source": "/docs/quickstart",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
     {
       "source": "/docs/api-quickstart",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
     {
       "source": "/docs/tts-in-five-minutes",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
     {
       "source": "/quickstart",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
     {
       "source": "/quickstarts/five-minute-guide",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
     {
       "source": "/core/quickstarts/five-minute-guide",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
     {
       "source": "/docs/get-started",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
     {
       "source": "/docs/getting-started",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
     {
       "source": "/getting-started",
-      "destination": "/docs/quickstart-five-minute"
+      "destination": "/docs/quickstart-five-minute",
+      "permanent": false
     },
 
     {
       "source": "/reference/postrimetts",
-      "destination": "/api-reference/coda/http"
+      "destination": "/api-reference/coda/http",
+      "permanent": false
     },
     {
       "source": "/reference/postrimetts-1",
-      "destination": "/api-reference/coda/http"
+      "destination": "/api-reference/coda/http",
+      "permanent": false
     },
     {
       "source": "/reference/post_v1-rime-tts",
-      "destination": "/api-reference/coda/http"
+      "destination": "/api-reference/coda/http",
+      "permanent": false
     },
     {
       "source": "/docs/rime-tts-http",
-      "destination": "/api-reference/coda/http"
+      "destination": "/api-reference/coda/http",
+      "permanent": false
     },
     {
       "source": "/api/v1/rime-tts",
-      "destination": "/api-reference/coda/http"
+      "destination": "/api-reference/coda/http",
+      "permanent": false
     },
     {
       "source": "/streaming-http",
-      "destination": "/api-reference/coda/http"
+      "destination": "/api-reference/coda/http",
+      "permanent": false
     },
     {
       "source": "/http-streaming",
-      "destination": "/api-reference/coda/http"
+      "destination": "/api-reference/coda/http",
+      "permanent": false
     },
     {
       "source": "/docs/streaming-http",
-      "destination": "/api-reference/coda/http"
+      "destination": "/api-reference/coda/http",
+      "permanent": false
     },
 
     {
       "source": "/docs/oov",
-      "destination": "/api-reference/other/oov"
+      "destination": "/api-reference/other/oov",
+      "permanent": false
     },
     {
       "source": "/api-reference/oov",
-      "destination": "/api-reference/other/oov"
+      "destination": "/api-reference/other/oov",
+      "permanent": false
     },
     {
       "source": "/docs/utilities/coverage-checking",
-      "destination": "/api-reference/other/oov"
+      "destination": "/api-reference/other/oov",
+      "permanent": false
     },
 
     {
       "source": "/api-reference/textnorm",
-      "destination": "/api-reference/other/textnorm"
+      "destination": "/api-reference/other/textnorm",
+      "permanent": false
     },
     {
       "source": "/docs/utilities/text-normalization",
-      "destination": "/docs/text-normalization"
+      "destination": "/docs/text-normalization",
+      "permanent": false
     },
     {
       "source": "/docs/text-processing",
-      "destination": "/docs/text-normalization"
+      "destination": "/docs/text-normalization",
+      "permanent": false
     },
 
     {
       "source": "/docs/voice-selection",
-      "destination": "/docs/voices"
+      "destination": "/docs/voices",
+      "permanent": false
     },
     {
       "source": "/features/voices",
-      "destination": "/docs/voices"
+      "destination": "/docs/voices",
+      "permanent": false
     },
 
     {
       "source": "/features/models",
-      "destination": "/docs/models"
+      "destination": "/docs/models",
+      "permanent": false
     },
     {
       "source": "/mist-api",
-      "destination": "/docs/models"
+      "destination": "/docs/models",
+      "permanent": false
     },
 
     {
       "source": "/docs/websocket",
-      "destination": "/docs/websockets"
+      "destination": "/docs/websockets",
+      "permanent": false
     },
     {
       "source": "/docs/websocket-json",
-      "destination": "/docs/websockets"
+      "destination": "/docs/websockets",
+      "permanent": false
     },
     {
       "source": "/docs/streaming-websocket-json",
-      "destination": "/docs/websockets"
+      "destination": "/docs/websockets",
+      "permanent": false
     },
     {
       "source": "/reference/websockets-json",
-      "destination": "/docs/websockets"
+      "destination": "/docs/websockets",
+      "permanent": false
     },
     {
       "source": "/reference/websockets",
-      "destination": "/docs/websockets"
+      "destination": "/docs/websockets",
+      "permanent": false
     },
     {
       "source": "/docs/api-reference/websockets",
-      "destination": "/docs/websockets"
+      "destination": "/docs/websockets",
+      "permanent": false
     },
 
     {
       "source": "/docs/arcana/websockets",
-      "destination": "/api-reference/arcana/websockets"
+      "destination": "/api-reference/arcana/websockets",
+      "permanent": false
     },
     {
       "source": "/docs/arcana-websockets",
-      "destination": "/api-reference/arcana/websockets"
+      "destination": "/api-reference/arcana/websockets",
+      "permanent": false
     },
     {
       "source": "/reference/arcana-websockets",
-      "destination": "/api-reference/arcana/websockets"
+      "destination": "/api-reference/arcana/websockets",
+      "permanent": false
     },
 
     {
       "source": "/docs/mist-v3-websockets",
-      "destination": "/api-reference/mistv3/websockets"
+      "destination": "/api-reference/mistv3/websockets",
+      "permanent": false
     },
     {
       "source": "/reference/mist-v3-websockets",
-      "destination": "/api-reference/mistv3/websockets"
+      "destination": "/api-reference/mistv3/websockets",
+      "permanent": false
     },
     {
       "source": "/api/mist-v3/websockets",
-      "destination": "/api-reference/mistv3/websockets"
+      "destination": "/api-reference/mistv3/websockets",
+      "permanent": false
     },
 
     {
       "source": "/docs/mist-v2-websockets",
-      "destination": "/api-reference/mistv2/websockets"
+      "destination": "/api-reference/mistv2/websockets",
+      "permanent": false
     },
     {
       "source": "/reference/mist-v2-websockets",
-      "destination": "/api-reference/mistv2/websockets"
+      "destination": "/api-reference/mistv2/websockets",
+      "permanent": false
     },
 
     {
       "source": "/docs/mist-websocket-json",
-      "destination": "/api-reference/mistv3/websockets-json"
+      "destination": "/api-reference/mistv3/websockets-json",
+      "permanent": false
     },
 
     {
       "source": "/docs/arcana/streaming-http",
-      "destination": "/api-reference/arcana/http"
+      "destination": "/api-reference/arcana/http",
+      "permanent": false
     },
     {
       "source": "/arcana-api",
-      "destination": "/api-reference/arcana/http"
+      "destination": "/api-reference/arcana/http",
+      "permanent": false
     },
 
     {
       "source": "/api/mist-v3/streaming-http",
-      "destination": "/api-reference/mistv3/http"
+      "destination": "/api-reference/mistv3/http",
+      "permanent": false
     },
     {
       "source": "/mist-v3",
-      "destination": "/api-reference/mistv3/http"
+      "destination": "/api-reference/mistv3/http",
+      "permanent": false
     },
     {
       "source": "/v1/mist-v3",
-      "destination": "/api-reference/mistv3/http"
+      "destination": "/api-reference/mistv3/http",
+      "permanent": false
     },
     {
       "source": "/api-reference/mist-v3",
-      "destination": "/api-reference/mistv3/http"
+      "destination": "/api-reference/mistv3/http",
+      "permanent": false
     },
     {
       "source": "/api-reference/mist-v3/http",
-      "destination": "/api-reference/mistv3/http"
+      "destination": "/api-reference/mistv3/http",
+      "permanent": false
     },
     {
       "source": "/docs/api-reference/mist-v3",
-      "destination": "/api-reference/mistv3/http"
+      "destination": "/api-reference/mistv3/http",
+      "permanent": false
     },
 
     {
       "source": "/mist-v2-api",
-      "destination": "/api-reference/mistv2/http"
+      "destination": "/api-reference/mistv2/http",
+      "permanent": false
     },
     {
       "source": "/api-reference/mist-v2",
-      "destination": "/api-reference/mistv2/http"
+      "destination": "/api-reference/mistv2/http",
+      "permanent": false
     },
     {
       "source": "/api-reference/mist-v2/http",
-      "destination": "/api-reference/mistv2/http"
+      "destination": "/api-reference/mistv2/http",
+      "permanent": false
     },
 
     {
       "source": "/api-reference/voices/all-v2",
-      "destination": "/api-reference/data/voices-v2"
+      "destination": "/api-reference/data/voices-v2",
+      "permanent": false
     },
     {
       "source": "/reference/data-voices-voice-details-json",
-      "destination": "/api-reference/data/voice-details"
+      "destination": "/api-reference/data/voice-details",
+      "permanent": false
     },
 
     {
       "source": "/docs/api",
-      "destination": "/docs/api-reference"
+      "destination": "/docs/api-reference",
+      "permanent": false
     },
     {
       "source": "/api",
-      "destination": "/docs/api-reference"
+      "destination": "/docs/api-reference",
+      "permanent": false
     },
     {
       "source": "/reference",
-      "destination": "/docs/api-reference"
+      "destination": "/docs/api-reference",
+      "permanent": false
     },
     {
       "source": "/reference/api",
-      "destination": "/docs/api-reference"
+      "destination": "/docs/api-reference",
+      "permanent": false
     },
     {
       "source": "/docs/v1-api-reference",
-      "destination": "/docs/api-reference"
+      "destination": "/docs/api-reference",
+      "permanent": false
     },
     {
       "source": "/docs/text-to-speech",
-      "destination": "/docs/api-reference"
+      "destination": "/docs/api-reference",
+      "permanent": false
     },
     {
       "source": "/docs/rest",
-      "destination": "/docs/api-reference"
+      "destination": "/docs/api-reference",
+      "permanent": false
     },
     {
       "source": "/docs/api-reference/utilities",
-      "destination": "/docs/api-reference"
+      "destination": "/docs/api-reference",
+      "permanent": false
     },
 
     {
       "source": "/authentication",
-      "destination": "/docs/api-authentication"
+      "destination": "/docs/api-authentication",
+      "permanent": false
     },
     {
       "source": "/core/authentication",
-      "destination": "/docs/api-authentication"
+      "destination": "/docs/api-authentication",
+      "permanent": false
     },
     {
       "source": "/cli/authentication",
-      "destination": "/docs/api-authentication"
+      "destination": "/docs/api-authentication",
+      "permanent": false
     },
     {
       "source": "/reference/api-authentication",
-      "destination": "/docs/api-authentication"
+      "destination": "/docs/api-authentication",
+      "permanent": false
     }
   ]
 }

--- a/docs/api-authentication.mdx
+++ b/docs/api-authentication.mdx
@@ -1,0 +1,42 @@
+---
+title: API authentication
+icon: key
+description: How to authenticate with the Rime TTS API using a bearer token.
+---
+
+All requests to the Rime API are authenticated with a **bearer token** in the `Authorization` header.
+
+## Get an API key
+
+1. Sign in at [app.rime.ai](https://app.rime.ai).
+2. Open the [API Tokens page](https://app.rime.ai/tokens).
+3. Create a new token and copy the value. Treat it like a password — anyone with the token can synthesize speech against your account.
+
+## Use the token
+
+Set the `Authorization` header on every request:
+
+```bash
+curl --request POST \
+  --url https://users.rime.ai/v1/rime-tts \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --header 'Content-Type: application/json' \
+  --header 'Accept: audio/mp3' \
+  --data '{"speaker":"astra","text":"hello","modelId":"coda","language":"en"}'
+```
+
+The same header is used for the HTTP endpoint, the WebSocket endpoints, and the metadata/utility endpoints.
+
+## CLI authentication
+
+The `rime` CLI manages your key for you. Run [`rime login`](/cli-reference/rime-auth) once and the CLI stores it at `~/.rime/rime.toml`. You can also set it explicitly via the `RIME_CLI_API_KEY` environment variable.
+
+## On-prem authentication
+
+On-prem deployments accept the same `Authorization: Bearer …` header. You can also pre-configure a key at the deployment level using the `RIME_API_KEY` environment variable, so callers don't need to send the header at all. See [the on-prem quickstart](/docs/on-prem/quickstart) for details.
+
+## Related
+
+- [Quickstart: TTS in five minutes](/docs/quickstart-five-minute)
+- [API reference index](/docs/api-reference)
+- [CLI authentication commands](/cli-reference/rime-auth)

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,0 +1,43 @@
+---
+title: API reference index
+description: Index of Rime's TTS HTTP, WebSocket, and metadata endpoints across all supported models.
+---
+
+Rime's TTS API is reached at `https://users.rime.ai/v1/rime-tts`. Authentication is a bearer token in the `Authorization` header — see [API authentication](/docs/api-authentication).
+
+Most clients should start with **Coda**, Rime's flagship model:
+
+- [Coda — Streaming HTTP](/api-reference/coda/http)
+- [Coda — WebSockets (`/ws`)](/api-reference/coda/websockets)
+- [Coda — WebSockets JSON (`/ws3`)](/api-reference/coda/websockets-json)
+
+For the cross-model overview of when to use each WebSocket endpoint, see [WebSocket API Overview](/docs/websockets).
+
+## TTS endpoints by model
+
+| Model | Streaming HTTP | WebSocket `/ws` | WebSocket JSON |
+| --- | --- | --- | --- |
+| **Coda** (flagship) | [HTTP](/api-reference/coda/http) | [/ws](/api-reference/coda/websockets) | [/ws3](/api-reference/coda/websockets-json) |
+| **Arcana** | [HTTP](/api-reference/arcana/http) | [/ws](/api-reference/arcana/websockets) | [/ws3](/api-reference/arcana/websockets-json) |
+| **Mist v3** | [HTTP](/api-reference/mistv3/http) | [/ws](/api-reference/mistv3/websockets) | [/ws3](/api-reference/mistv3/websockets-json) |
+| **Mist v2** | [HTTP](/api-reference/mistv2/http) · [SSE](/api-reference/mistv2/sse) | [/ws](/api-reference/mistv2/websockets) | [/ws2](/api-reference/mistv2/websockets-json) |
+
+Mist v2 also exposes non-streaming JSON-wrapped formats: [MP3](/api-reference/mistv2/json-mp3), [WAV](/api-reference/mistv2/json-wav), [Opus/OGG](/api-reference/mistv2/json-ogg), [G.711 μ-law](/api-reference/mistv2/json-mulaw).
+
+## Metadata endpoints
+
+- [List All Voices](/api-reference/data/voices-v2) — `GET /data/voices/all-v2.json`
+- [List Voice Details](/api-reference/data/voice-details) — `GET /data/voices/voice_details.json`
+
+## Utility endpoints
+
+- [Coverage (out-of-vocabulary check)](/api-reference/other/oov) — `POST /oov`
+- [Text Normalization](/api-reference/other/textnorm) — `POST /textnorm`
+
+## Related
+
+- [Quickstart: TTS in five minutes](/docs/quickstart-five-minute)
+- [Models](/docs/models) — comparing Coda, Arcana, and Mist
+- [Voices](/docs/voices) — voice lineup and language support
+- [Latency tuning](/docs/latency)
+- [Changelog](/docs/changelog)


### PR DESCRIPTION
## Summary

Adds two new landing pages and ~55 redirects targeting URLs that coding agents are searching for against `docs.rime.ai` but that didn't exist. Stacked on top of #221 so the diff here shows only the redirect/landing-page changes.

Source data: a Usesapient API-test run that captured the failed paths AI coding agents hit while trying to build voice agents with minimal instruction.

## New pages

### 1) `docs/api-reference.mdx` — `/docs/api-reference`

The single most-requested missing path (9 agent hits). A flat hub listing every TTS, metadata, and utility endpoint with links to each model's HTTP / WebSocket / WebSocket-JSON page. **Hidden from the left nav** (only reachable via direct URL / redirects) so it doesn't duplicate the existing API Reference tab for humans.

### 2) `docs/api-authentication.mdx` — `/docs/api-authentication`

Multiple agents looked for an auth page (`/authentication`, `/core/authentication`, `/cli/authentication`, `/reference/api-authentication`). There was no dedicated page; auth was only mentioned in the quickstart prereqs. Added under **Getting started** in the left nav. Covers bearer-token format, creating keys at `app.rime.ai/tokens`, CLI auth (`rime login`), and on-prem `RIME_API_KEY`.

## Redirects added (~55, grouped by destination)

| Destination | Sources |
| --- | --- |
| `/docs/quickstart-five-minute` | `/docs/quickstart`, `/docs/api-quickstart`, `/docs/tts-in-five-minutes`, `/quickstart`, `/quickstarts/five-minute-guide`, `/core/quickstarts/five-minute-guide`, `/docs/get-started`, `/docs/getting-started`, `/getting-started` |
| `/api-reference/coda/http` (new flagship) | `/reference/postrimetts`, `/reference/postrimetts-1`, `/reference/post_v1-rime-tts`, `/docs/rime-tts-http`, `/api/v1/rime-tts`, `/streaming-http`, `/http-streaming`, `/docs/streaming-http` |
| `/api-reference/other/oov` | `/docs/oov`, `/api-reference/oov`, `/docs/utilities/coverage-checking` |
| `/api-reference/other/textnorm` | `/api-reference/textnorm` |
| `/docs/text-normalization` | `/docs/utilities/text-normalization`, `/docs/text-processing` |
| `/docs/voices` | `/docs/voice-selection`, `/features/voices` |
| `/docs/models` | `/features/models`, `/mist-api` |
| `/docs/websockets` (existing overview) | `/docs/websocket`, `/docs/websocket-json`, `/docs/streaming-websocket-json`, `/reference/websockets-json`, `/reference/websockets`, `/docs/api-reference/websockets` |
| `/api-reference/arcana/websockets` | `/docs/arcana/websockets`, `/docs/arcana-websockets`, `/reference/arcana-websockets` |
| `/api-reference/mistv3/websockets` | `/docs/mist-v3-websockets`, `/reference/mist-v3-websockets`, `/api/mist-v3/websockets` |
| `/api-reference/mistv2/websockets` | `/docs/mist-v2-websockets`, `/reference/mist-v2-websockets` |
| `/api-reference/mistv3/websockets-json` | `/docs/mist-websocket-json` |
| `/api-reference/arcana/http` | `/docs/arcana/streaming-http`, `/arcana-api` |
| `/api-reference/mistv3/http` | `/api/mist-v3/streaming-http`, `/mist-v3`, `/v1/mist-v3`, `/api-reference/mist-v3`, `/api-reference/mist-v3/http`, `/docs/api-reference/mist-v3` |
| `/api-reference/mistv2/http` | `/mist-v2-api`, `/api-reference/mist-v2`, `/api-reference/mist-v2/http` |
| `/api-reference/data/voices-v2` | `/api-reference/voices/all-v2` |
| `/api-reference/data/voice-details` | `/reference/data-voices-voice-details-json` |
| `/docs/api-reference` (new hub) | `/docs/api`, `/api`, `/reference`, `/reference/api`, `/docs/v1-api-reference`, `/docs/text-to-speech`, `/docs/rest`, `/docs/api-reference/utilities` |
| `/docs/api-authentication` (new) | `/authentication`, `/core/authentication`, `/cli/authentication`, `/reference/api-authentication` |

## Intentionally not handled

- `https://users.rime.ai/v1/rime-tts` — the agent went to the actual API host, not the docs host. Nothing to fix on the docs side.
- `/docs/llms.txt` — Mintlify auto-generates `/llms.txt` at the docs root; the agent's `/docs/` prefix is just wrong. Only one agent hit this and a redirect to a generated file is risky.

## Test plan

- [ ] Open the local Mintlify preview and confirm `/docs/api-reference` and `/docs/api-authentication` render correctly.
- [ ] Confirm `/docs/api-authentication` appears in the **Getting started** group in the left nav.
- [ ] Confirm `/docs/api-reference` does **not** appear in the left nav (intentional).
- [ ] Spot-check a few redirects in the preview: `/docs/quickstart`, `/api`, `/docs/oov`, `/docs/mist-v3-websockets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)