### PR TITLE
Readability and layout improvements across the docs

### DIFF
--- a/api-reference/arcana/http.mdx
+++ b/api-reference/arcana/http.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Streaming HTTP'
+description: "Arcana streaming HTTP endpoint: synthesize speech and stream audio back in MP3, WAV, PCM, μ-law, or Opus."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/arcana/websockets-json.mdx
+++ b/api-reference/arcana/websockets-json.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Websockets JSON'
+description: "Arcana JSON WebSocket (/ws3): structured events with base64 audio chunks and word-level timestamps."
 api: 'GET wss://users-ws.rime.ai/ws3'
 authMethod: "bearer"
 ---

--- a/api-reference/arcana/websockets.mdx
+++ b/api-reference/arcana/websockets.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Websockets'
+description: "Arcana plain-text WebSocket (/ws): send text, receive raw audio bytes in the requested format."
 api: 'GET wss://users-ws.rime.ai/ws'
 authMethod: "bearer"
 ---

--- a/api-reference/coda/http.mdx
+++ b/api-reference/coda/http.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Streaming HTTP'
+description: "Coda streaming HTTP endpoint: synthesize speech with Rime's flagship model and stream audio back."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/coda/websockets-json.mdx
+++ b/api-reference/coda/websockets-json.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Websockets JSON'
+description: "Coda JSON WebSocket (/ws3): structured events with base64 audio chunks and word-level timestamps."
 api: 'GET wss://users-ws.rime.ai/ws3'
 authMethod: "bearer"
 ---

--- a/api-reference/coda/websockets.mdx
+++ b/api-reference/coda/websockets.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Websockets'
+description: "Coda plain-text WebSocket (/ws): send text, receive raw audio bytes."
 api: 'GET wss://users-ws.rime.ai/ws'
 authMethod: "bearer"
 ---

--- a/api-reference/data/voice-details.mdx
+++ b/api-reference/data/voice-details.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'List Voice Details'
+description: "Voice metadata endpoint: list every Rime voice with demographic and model details."
 api: 'GET https://users.rime.ai/data/voices/voice_details.json'
 ---
 

--- a/api-reference/data/voices-v2.mdx
+++ b/api-reference/data/voices-v2.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'List All Voices'
+description: "List every Rime voice, keyed by modelId and language."
 api: 'GET https://users.rime.ai/data/voices/all-v2.json'
 ---
 

--- a/api-reference/data/voices.mdx
+++ b/api-reference/data/voices.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'List All Voices'
+description: "List of Rime voices (legacy URL — see voices-v2 for the canonical endpoint)."
 api: 'GET https://users.rime.ai/data/voices/all-v2.json'
 ---
 

--- a/api-reference/mistv2/http.mdx
+++ b/api-reference/mistv2/http.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Streaming HTTP'
+description: "Mist v2 streaming HTTP endpoint."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv2/json-mp3.mdx
+++ b/api-reference/mistv2/json-mp3.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MP3 over JSON'
+description: "Mist v2 non-streaming endpoint that returns base64 MP3 audio inside a JSON envelope."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv2/json-mulaw.mdx
+++ b/api-reference/mistv2/json-mulaw.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'μ-law over JSON'
+description: "Mist v2 non-streaming endpoint that returns base64 G.711 μ-law audio inside a JSON envelope."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv2/json-ogg.mdx
+++ b/api-reference/mistv2/json-ogg.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'OGG over JSON'
+description: "Mist v2 non-streaming endpoint that returns base64 Opus/Ogg audio inside a JSON envelope."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv2/json-wav.mdx
+++ b/api-reference/mistv2/json-wav.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAV over JSON'
+description: "Mist v2 non-streaming endpoint that returns base64 WAV audio inside a JSON envelope."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv2/sse.mdx
+++ b/api-reference/mistv2/sse.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server-sent Events'
+description: "Mist v2 Server-Sent Events endpoint for streaming audio chunks over text/event-stream."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv2/websockets-json.mdx
+++ b/api-reference/mistv2/websockets-json.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Websockets JSON'
+description: "Mist v2 JSON WebSocket (/ws2): structured events with base64 audio chunks and word-level timestamps."
 api: 'GET wss://users-ws.rime.ai/ws2'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv2/websockets.mdx
+++ b/api-reference/mistv2/websockets.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Websockets'
+description: "Mist v2 plain-text WebSocket (/ws): send text, receive raw audio bytes."
 api: 'GET wss://users-ws.rime.ai/ws'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv3/http.mdx
+++ b/api-reference/mistv3/http.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Streaming HTTP'
+description: "Mist v3 streaming HTTP endpoint: low-latency TTS with the updated Mist engine."
 api: 'POST https://users.rime.ai/v1/rime-tts'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv3/websockets-json.mdx
+++ b/api-reference/mistv3/websockets-json.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Websockets JSON'
+description: "Mist v3 JSON WebSocket (/ws3): structured events with base64 audio chunks and word-level timestamps."
 api: 'GET wss://users-ws.rime.ai/ws3'
 authMethod: "bearer"
 ---

--- a/api-reference/mistv3/websockets.mdx
+++ b/api-reference/mistv3/websockets.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Websockets'
+description: "Mist v3 plain-text WebSocket (/ws): send text, receive raw audio bytes."
 api: 'GET wss://users-ws.rime.ai/ws'
 authMethod: "bearer"
 ---

--- a/api-reference/other/oov.mdx
+++ b/api-reference/other/oov.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Coverage'
+description: "Coverage endpoint: check which input words are not yet in Rime's pronunciation dictionary."
 api: 'POST  https://users.rime.ai/oov'
 authMethod: "bearer"
 ---
@@ -162,3 +163,15 @@ HttpResponse<String> response = Unirest.post("https://users.rime.ai/oov")
 ```
 
 </RequestExample>
+
+<ResponseExample>
+
+```json 200 — words not in dictionary
+["testt", "testtt"]
+```
+
+```json 200 — all words covered
+[]
+```
+
+</ResponseExample>

--- a/api-reference/other/textnorm.mdx
+++ b/api-reference/other/textnorm.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Text Normalization'
+description: "Text normalization endpoint: returns the normalized form of input text — exactly what the TTS model sees before synthesis."
 api: 'POST  https://optimize.rime.ai/textnorm'
 authMethod: "bearer"
 ---
@@ -163,3 +164,13 @@ HttpResponse<String> response = Unirest.post("https://optimize.rime.ai/textnorm"
 ```
 
 </RequestExample>
+
+<ResponseExample>
+
+```json 200
+{
+  "normalized": "one two three four, one, eight hundred, four four four, four one four one"
+}
+```
+
+</ResponseExample>

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: Quickstart
+description: "Quick orientation to Rime's TTS API."
 icon: rocket
 ---
 

--- a/docs/api-authentication.mdx
+++ b/docs/api-authentication.mdx
@@ -35,6 +35,17 @@ The `rime` CLI manages your key for you. Run [`rime login`](/cli-reference/rime-
 
 On-prem deployments accept the same `Authorization: Bearer …` header. You can also pre-configure a key at the deployment level using the `RIME_API_KEY` environment variable, so callers don't need to send the header at all. See [the on-prem quickstart](/docs/on-prem/quickstart) for details.
 
+## Common auth errors
+
+If your request fails authentication, the API returns `401 Unauthorized` with a short plain-text body explaining why:
+
+| Status | Body | Cause |
+| :--- | :--- | :--- |
+| `401` | `missing headers` | No `Authorization` header was sent. |
+| `401` | `invalid api key` | The token is not recognized, or it was sent without the `Bearer` scheme. |
+
+Always send the header as `Authorization: Bearer <token>` (capital `B`). The token alone, without `Bearer`, is rejected.
+
 ## Related
 
 - [Quickstart: TTS in five minutes](/docs/quickstart-five-minute)

--- a/docs/cerebrium.mdx
+++ b/docs/cerebrium.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cerebrium
+description: "Deploy Rime TTS on Cerebrium's serverless infrastructure."
 ---
 
 import { IntegrationHeader } from '/snippets/integration-header.mdx'

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,5 +1,6 @@
 ---
 title: Changelog
+description: "Release notes for Rime's TTS API and on-prem images."
 icon: list
 ---
 

--- a/docs/custom-pauses.mdx
+++ b/docs/custom-pauses.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom pauses'
+description: "Insert pauses of specific durations into Mist family synthesis using angle-bracket markers."
 ---
 
 <Note>Custom pauses are supported by **Mist**, **Mist v2**, and **Mist v3**.</Note>
@@ -13,7 +14,7 @@ For example, `<750>` inserts a pause of 750 milliseconds (or .75 seconds). To he
 |   <audio controls src="https://rime.ai/sounds/docs/wait_no_pause.wav"></audio>     |    wait, are you actually serious.      |
 |   <audio controls src="https://rime.ai/sounds/docs/wait_750.wav"></audio>    |      wait. `<750>` are you actually serious.        |
 
-> **Note:** When making an API request, you must set `pauseBetweenBrackets` to `true`. The request would look like this:
+<Note>When making an API request, you must set `pauseBetweenBrackets` to `true`. The request would look like this:</Note>
 
 ```python Custom Pause Example
 {

--- a/docs/custom-pronunciation.mdx
+++ b/docs/custom-pronunciation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom pronunciation'
+description: "Specify pronunciations for uncommon words in Mist family synthesis using Rime's phonetic alphabet."
 ---
 
 <Note>Custom pronunciation is supported by **Mist**, **Mist v2**, and **Mist v3**.</Note>
@@ -16,7 +17,7 @@ Custom pronunciations use Rime's phonetic alphabet (detailed [below](#the-rime-p
 |-----------------|--------------------------|
 |   <audio controls src="https://rime.ai/sounds/docs/gorbulets.wav"></audio>     |    actually, `{g1orby0ul2Ets}` is a word i just made up.      |
 
-> **Note:** When making an API request, you must set `phonemizeBetweenBrackets` to `true`. The request would look like this:
+<Note>When making an API request, you must set `phonemizeBetweenBrackets` to `true`. The request would look like this:</Note>
 
 ```python Custom pronunciation example
 {
@@ -106,7 +107,7 @@ Below is a guide to Rime's phonetic alphabet and how to input syllabic stress.
 | z | **z**oo |
 | Z | plea**s**ure |
 
-### Stress
+## Stress
 
 For primary stress, put `1` before the relevant vowel. For example, `comma` would be `{k1am0x}`.
 

--- a/docs/daily.mdx
+++ b/docs/daily.mdx
@@ -1,5 +1,6 @@
 ---
 title: Daily
+description: "Use Rime TTS with Daily's real-time video and voice platform."
 ---
 
 import { IntegrationHeader } from '/snippets/integration-header.mdx'

--- a/docs/hathora.mdx
+++ b/docs/hathora.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hathora
+description: "Use Rime TTS with Hathora's edge compute platform."
 ---
 
 import { IntegrationHeader } from '/snippets/integration-header.mdx'

--- a/docs/homographs.mdx
+++ b/docs/homographs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Homographs (Mist v2 only)
+description: "Disambiguate same-spelling-different-pronunciation words on Mist v2."
 ---
 
 <Note>Homograph disambiguation is supported by **Mist v2** only.</Note>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,9 +1,29 @@
 ---
 title: Introduction
+description: "Get started with Rime's TTS API — Coda flagship, multilingual support, real-time conversational latency."
 icon: book
 ---
 
 Rime provides industry-leading text-to-speech (TTS) AI models built for **real-time conversational experiences at scale**. Our latest flagship model, **Coda**, delivers authentic, natural, and expressive speech with the speed and reliability required for production voice AI, whether you're building intelligent IVRs, multilingual voice agents, or anything in between.
+
+## Hello from Coda in 30 seconds
+
+```bash
+curl --request POST \
+  --url https://users.rime.ai/v1/rime-tts \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --header 'Content-Type: application/json' \
+  --header 'Accept: audio/mp3' \
+  --output hello.mp3 \
+  --data '{
+    "speaker": "astra",
+    "text": "Hello from Coda.",
+    "modelId": "coda",
+    "language": "en"
+  }'
+```
+
+Get your `YOUR_API_KEY` from the [API Tokens page](https://app.rime.ai/tokens). For a full walkthrough, see the [five-minute quickstart](/docs/quickstart-five-minute).
 
 ## Rime's TTS Models
 
@@ -24,17 +44,27 @@ Rime now offers a suite of models tailored for different production needs:
 - **Mist v3**
     - `modelId: mistv3`
     - Major update to the Mist engine with **typical TTFB well below 100ms** — significantly faster than previous Mist versions while preserving quality and predictability.
-- **Mistv2**
+- **Mist v2**
     - `modelId: mistv2`
     - Optimized for **speed and fine-grained control**, giving you accurate pronunciation and high concurrency for use cases that demand quick synthesis and customization.
     - This is the highest precision and lowest WER model on the market; use this when perfect fidelity to text is needed.
 
 ## What Makes Coda Different
 
-- **Real-Time Conversational Performance:** Coda delivers TTS with industry-leading latency, enabling natural back-and-forth interactions without awkward pauses — fast enough for mid-utterance control and barge-in.
-- **Multilingual Support:** A single model speaks Arabic, English, French, German, Japanese, Portuguese, and Spanish using the same expressive voice lineup.
-- **Word-Level Timestamps:** Structural metadata enables text-audio alignment, real-time highlighting, better interruption handling, and smarter orchestration in voice applications.
-- **Enterprise-Grade Deployment:** Coda scales with high concurrency per machine and a robust suite of TTS-specific observability metrics, and is available on cloud and on-premises.
+<CardGroup cols={2}>
+  <Card title="Real-time conversational performance" icon="bolt">
+    Industry-leading latency enables natural back-and-forth interactions — fast enough for mid-utterance control and barge-in.
+  </Card>
+  <Card title="Multilingual support" icon="globe">
+    One model speaks Arabic, English, French, German, Japanese, Portuguese, and Spanish using a shared expressive voice lineup.
+  </Card>
+  <Card title="Word-level timestamps" icon="clock">
+    Structural metadata enables text-audio alignment, real-time highlighting, better interruption handling, and smarter orchestration.
+  </Card>
+  <Card title="Enterprise-grade deployment" icon="server">
+    Scales with high concurrency per machine, ships TTS-specific observability metrics, and runs on cloud or on-premises.
+  </Card>
+</CardGroup>
 
 ## Language & Voice Support
 

--- a/docs/latency.mdx
+++ b/docs/latency.mdx
@@ -1,5 +1,6 @@
 ---
 title: Latency
+description: "How Rime achieves sub-200ms TTS latency, factors that affect response time, and tips to reduce it further."
 icon: gauge-simple-max
 ---
 
@@ -38,11 +39,37 @@ curl -X POST http://users.rime.ai/v1/rime-tts \
   -d '{"text": "I love the book that she gave me. And I was so happy that she gave it to me.", "speaker": "cove",  "modelId": "mistv3"}'
 ```
 
+To actually consume a streaming response in Python, iterate over the response body as it arrives instead of buffering the whole thing:
+
+```python Python
+import requests
+
+with requests.post(
+    "https://users.rime.ai/v1/rime-tts",
+    headers={
+        "Authorization": f"Bearer {RIME_API_KEY}",
+        "Content-Type": "application/json",
+        "Accept": "audio/mp3",
+    },
+    json={
+        "speaker": "astra",
+        "text": "Hello from Coda.",
+        "modelId": "coda",
+        "language": "en",
+    },
+    stream=True,
+) as response:
+    response.raise_for_status()
+    with open("hello.mp3", "wb") as f:
+        for chunk in response.iter_content(chunk_size=4096):
+            f.write(chunk)
+```
+
 ### Recommendations for reducing response time
 
 <Tip>For the lowest cloud latency, use `mistv3` — typical TTFB is well below 100ms.</Tip>
 
-- Use the API parameter `noTextNormalization`, which turns off text normalization, to reduce the amount of computation needed to prepare input text for TTS inference. This can safely be used in cases where there are no digits, abbreviations, or tricky punctuation, such as in `Yes, I grew up on one twenty-three Main Street in Oakland, California.` instead of `Yes, I grew up on 123 Main St. in Oakland, CA.`.
+- Use the API parameter [`noTextNormalization`](/docs/text-normalization), which turns off text normalization, to reduce the amount of computation needed to prepare input text for TTS inference. This can safely be used in cases where there are no digits, abbreviations, or tricky punctuation, such as in `Yes, I grew up on one twenty-three Main Street in Oakland, California.` instead of `Yes, I grew up on 123 Main St. in Oakland, CA.`.
 - Request audio that meets the needs of your application. Remember: Smaller payloads move across the network more quickly. For example, if you're building an application for telephony, request 8000kHz-sampled audio using the `samplingRate` parameter.
 <Info>Rime's models produce PCM audio by default, and conversion and downsampling must take place for sampling rates other than 22kHz. Still, the reduction in payload size and therefore network overhead more than makes up for increased server processing time.</Info>
 

--- a/docs/linguistics.mdx
+++ b/docs/linguistics.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Linguistics and TTS'
+description: "Why TTS is hard: the one-to-many problem in linguistics and how Rime gives you customization controls."
 ---
 
 Why is solving TTS and synthesizing realistic speech so difficult?
@@ -8,4 +9,4 @@ One over-arching reason is the **one-to-many problem** in linguistics: One text 
 
 While Rime remains opinionated on default acoustic realization, and the voices will speak fluently and correctly out-of-the-box, Rime is unique among next-gen TTS offerings in allowing users to customize their output. 
 
-The API also allows you to make extremely low-level adjustments for your particular use case, such as custom pauses and custom pronunciations. To see all the available customization options, check the pages in the **Customizing Speech** folder in the menu.
+The API also allows you to make extremely low-level adjustments for your particular use case, such as custom pauses and custom pronunciations. To see all the available customization options, check the pages in the **Customizing Mist** group in the menu.

--- a/docs/livekit.mdx
+++ b/docs/livekit.mdx
@@ -1,5 +1,6 @@
 ---
 title: LiveKit
+description: "Use Rime TTS with LiveKit's real-time platform for voice agents."
 ---
 
 import { IntegrationHeader } from '/snippets/integration-header.mdx'

--- a/docs/lovable.mdx
+++ b/docs/lovable.mdx
@@ -1,5 +1,6 @@
 ---
 title: Lovable
+description: "Build voice apps in Lovable using Rime's TTS."
 ---
 
 import { IntegrationHeader } from '/snippets/integration-header.mdx'

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -1,5 +1,6 @@
 ---
 title: Models
+description: "Pick the right Rime model: Coda (flagship), Arcana, Mist v3, Mist v2."
 icon: cube
 ---
 
@@ -8,6 +9,15 @@ Models are constantly being trained and fine-tuned based on user and customer fe
 <Tip>Rime's API is available in multiple regions. Use the [regional endpoint](/docs/regional-endpoints) closest to your deployment for the lowest latency.</Tip>
 
 Rime currently has five models in production: `coda`, `arcanav3`, `arcanav2`, `mistv3`, and `mistv2`. All are available via the cloud API and on-premises.
+
+## Which model should I use?
+
+| Pick this | When |
+| :--- | :--- |
+| `coda` | Real-time conversational agents needing flagship realism. Good default for most apps. |
+| `arcana` | Multilingual code-switching across 10+ languages, including Hindi, Hebrew, and Tamil. |
+| `mistv3` | Sub-100ms TTFB with the classic Mist lineup; plus features like [`phonemizeBetweenBrackets`](/docs/custom-pronunciation), [`pauseBetweenBrackets`](/docs/custom-pauses), and OOV submission. |
+| `mistv2` | Maximum pronunciation precision and lowest WER. Use when perfect fidelity to text is required. |
 
 ## Coda
 
@@ -30,16 +40,18 @@ Rime currently has five models in production: `coda`, `arcanav3`, `arcanav2`, `m
 * Supports the [`spell()` function](/docs/spell) for spelling out sequences letter by letter or number by number
 * Available via `modelId: arcana` through Rime's API endpoints
 
-## Mist
+## Mist v3
 
 **Mist v3**, released March 2026, is a major update to the engine powering our classic Mist model.
 
 * Typical TTFB is now well below 100ms — a significant performance improvement over previous versions, achieved without sacrificing the quality and predictability of Mist
 * `modelId: mistv3`
 * Our most popular Mist speakers are all available — see the [full voice list](/api-reference/data/voices)
-* `speedAlpha` behavior is reversed compared to Mist and Mist v2, bringing it to parity with Arcana: **higher values produce faster speech**
+* [`speedAlpha`](/docs/speed) behavior is reversed compared to Mist and Mist v2, bringing it to parity with Arcana: **higher values produce faster speech**
 
-**Mistv2**, released February 2025, has the following features:
+## Mist v2
+
+**Mist v2**, released February 2025, has the following features:
 
 * Multi-lingual English + Spanish, plus more languages coming soon
 * More realistic speech with natural and contextual nuances
@@ -47,11 +59,15 @@ Rime currently has five models in production: `coda`, `arcanav3`, `arcanav2`, `m
 * Ultra-fast on-prem latency of ~70ms, perfect for real-time applications
 * More accents, demographics, and speaking styles
 
+## Mist (legacy)
+
 **Mist** is Rime’s next-generation TTS engine, released April 2023, capable of synthesizing conversational speech. Using the `modelId` parameter for Rime’s TTS endpoints, specifying `mistv2` or `mist`, will allow you to synthesize speech using this newer family of models. As of February 2025, the default value for `modelId` when unspecified is `mist`.
 
 **Model v1 was released in April 2022 and has been deprecated.**
 
 ## Additional controls
+
+<Note>The controls in this section apply to Arcana only. Coda, Mist v3, and Mist v2 do not expose `temperature`, `top_p`, or `repetition_penalty`.</Note>
 
 Arcana also supports several additional controls due to its LLM backbone. We recommend leaving these on the default values.
 
@@ -59,8 +75,8 @@ Arcana also supports several additional controls due to its LLM backbone. We rec
   * **Low** (0): Produces more predictable and focused speech.
   * **High** (1+): Introduces variability in prosody and expression, potentially leading to more dynamic speech patterns.
 * `repetition_penalty`: Discourages the model from repeating the same sounds.
-  * **Low** (&lt;1): May result in repetitive speech patterns.
-  * **High** (&gt;1): Encourages variation, leading to more natural-sounding speech and realistic laughter.
+  * **Low** (`<1`): May result in repetitive speech patterns.
+  * **High** (`>1`): Encourages variation, leading to more natural-sounding speech and realistic laughter.
 * `top_p`: Determines the diversity of choices by limiting the selection to a subset of probable sounds.
   * **Low** (0): Restricts the model to the most probable sounds, resulting in more monotonic speech.
   * **High** (1): Allows for a broader range of sound choices, enhancing the naturalness and variability of speech.

--- a/docs/on-prem/helmcharts.mdx
+++ b/docs/on-prem/helmcharts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Helm charts
+description: "Deploy Rime on-prem using Helm charts on Kubernetes."
 ---
 
 This document provides information about the Helm chart for deploying Rime Labs services on Kubernetes.

--- a/docs/on-prem/load-balancing.mdx
+++ b/docs/on-prem/load-balancing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Load balancing
+description: "Load-balance Rime on-prem deployments using the ORCA cost-header signal."
 ---
 
 To ensure real-time streaming, it is often necessary to limit the number of

--- a/docs/on-prem/metrics.mdx
+++ b/docs/on-prem/metrics.mdx
@@ -1,5 +1,6 @@
 ---
 title: Metrics
+description: "Observability metrics exposed by Rime on-prem containers."
 ---
 Keeping track of system metrics is crucial for maintaining a stable Rime self-hosted deployment. These insights help guide decisions about scaling and performance. To support this, Rime services expose multiple endpoints that let you monitor system health.
 

--- a/docs/on-prem/performance.mdx
+++ b/docs/on-prem/performance.mdx
@@ -1,5 +1,6 @@
 ---
 title: Performance tuning
+description: "Tune Rime on-prem deployments for throughput, latency, and concurrency."
 ---
 
 # Overview

--- a/docs/on-prem/prometheus.mdx
+++ b/docs/on-prem/prometheus.mdx
@@ -1,5 +1,6 @@
 ---
 title: Prometheus integration
+description: "Scrape Rime on-prem metrics with Prometheus."
 ---
 Prometheus is an adaptable system for tracking and alerting, commonly used to scrape and review numerous operating metrics. This document details how to incorporate Prometheus into a privately hosted setup for Rime.
 

--- a/docs/on-prem/quickstart.mdx
+++ b/docs/on-prem/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: Quickstart
+description: "Get Rime running on-prem in your environment."
 ---
 
 <Tip>On-prem is  now **public and generally available!** For more information regarding access to Docker images and pricing info, reach out to help@rime.ai.</Tip>
@@ -19,7 +20,7 @@ With an on-premises deployment, all sensitive data remains within your corporate
 ### Latency
 
 - **Coda:** Available on-premises. Setup details and performance numbers coming in a follow-up release.
-- **Mistv2:** Our tests have shown median latency of **175ms** with randomly generated sentences between 40 and 50 characters on A10Gs and similar GPUs.
+- **Mist v2:** Our tests have shown median latency of **175ms** with randomly generated sentences between 40 and 50 characters on A10Gs and similar GPUs.
 - **Arcana:** See [performance tuning](/docs/on-prem/performance#metrics).
 
 ## Components

--- a/docs/privacy-compliance.mdx
+++ b/docs/privacy-compliance.mdx
@@ -1,13 +1,23 @@
 ---
 title: Privacy and compliance
+description: "Rime's security framework, SOC 2 Type II and HIPAA compliance, and how customer data is handled."
 icon: clipboard-list
 ---
 
 Rime is committed to protecting the security and privacy of our users' data. We have implemented a comprehensive security framework to ensure the safety of our users' information. Email us at [info@rime.ai](mailto:info@rime.ai) to request a compliance report.
 
-As of May 2025, we are SOC 2 Type II compliant. 
+## Certifications
 
-As of February 2024, we are [HIPAA compliant](https://rime.ai/blog/hipaa-compliance). 
+<CardGroup cols={2}>
+  <Card title="SOC 2 Type II" icon="shield-check">
+    As of May 2025.
+  </Card>
+  <Card title="HIPAA" icon="shield-check" href="https://rime.ai/blog/hipaa-compliance">
+    As of February 2024.
+  </Card>
+</CardGroup>
+
+## Data handling
 
 As a general practice, we don't collect customer data beyond character count unless requested. If you have concerns, we are happy to sign an MSA or BAA to outline specific terms.
 

--- a/docs/punctuation.mdx
+++ b/docs/punctuation.mdx
@@ -48,7 +48,7 @@ Rime's models treat each punctuation mark as a prosodic cue:
 | <audio controls src="https://rime.ai/sounds/docs/soitskindafunnycomma.wav"></audio> | so, it's kind of funny. | A comma creates a slight pause. |
 | <audio controls src="https://rime.ai/sounds/docs/soitskindafunnyperiod.wav"></audio> | so. it's kind of funny. | A period creates a longer pause. |
 
-For pauses of a specific duration on Mist, use the `pauseBetweenBrackets` parameter — see [Custom pauses](/docs/custom-pauses).
+For pauses of a specific duration on Mist, use the [`pauseBetweenBrackets`](/docs/custom-pauses) parameter — see [Custom pauses](/docs/custom-pauses).
 
 ## Common prosody problems and fixes
 

--- a/docs/quickstart-cli.mdx
+++ b/docs/quickstart-cli.mdx
@@ -1,5 +1,6 @@
 ---
 title: CLI Quickstart
+description: "Install the Rime CLI and synthesize your first audio clip from the terminal."
 icon: terminal
 ---
 

--- a/docs/quickstart-five-minute.mdx
+++ b/docs/quickstart-five-minute.mdx
@@ -1,5 +1,6 @@
 ---
 title: TTS in five minutes
+description: "Generate your first Rime TTS audio clip in five minutes using Python or JavaScript."
 icon: rocket
 ---
 
@@ -260,7 +261,9 @@ Browse all available voices on the [Voices](/docs/voices) page.
 
 ## Custom pronunciation
 
-The `mistv2` and `mistv3` models let you specify the pronunciation of brand names or uncommon words using Rime's [phonetic alphabet](/docs/custom-pronunciation). Add the custom pronunciation in curly brackets and set `phonemizeBetweenBrackets` to `true`:
+<Note>Custom pronunciation is a Mist-family feature. Coda and Arcana do not support [`phonemizeBetweenBrackets`](/docs/custom-pronunciation).</Note>
+
+The `mistv2` and `mistv3` models let you specify the pronunciation of brand names or uncommon words using Rime's [phonetic alphabet](/docs/custom-pronunciation). Add the custom pronunciation in curly brackets and set [`phonemizeBetweenBrackets`](/docs/custom-pronunciation) to `true`:
 
 <CodeGroup>
 ```python Python

--- a/docs/quickstart-livekit.mdx
+++ b/docs/quickstart-livekit.mdx
@@ -1,5 +1,6 @@
 ---
 title: LiveKit Quickstart
+description: "Build a real-time voice agent in your browser using LiveKit Agents + Rime TTS."
 icon: rocket
 ---
 

--- a/docs/regional-endpoints.mdx
+++ b/docs/regional-endpoints.mdx
@@ -1,5 +1,6 @@
 ---
 title: Regional endpoints
+description: "Route requests to the Rime region closest to your application for the lowest latency."
 icon: globe
 ---
 

--- a/docs/replit.mdx
+++ b/docs/replit.mdx
@@ -1,5 +1,6 @@
 ---
 title: Replit
+description: "Use Rime TTS inside Replit projects."
 ---
 
 import { IntegrationHeader } from '/snippets/integration-header.mdx'

--- a/docs/signalwire.mdx
+++ b/docs/signalwire.mdx
@@ -1,5 +1,6 @@
 ---
 title: SignalWire
+description: "Integrate Rime TTS with SignalWire's communications platform."
 ---
 
 import { IntegrationHeader } from '/snippets/integration-header.mdx'

--- a/docs/speed.mdx
+++ b/docs/speed.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Playback speed'
+description: "Control speaking speed in Rime synthesis using speedAlpha and inlineSpeedAlpha."
 icon: forward-fast
 ---
 
@@ -16,8 +17,10 @@ Overall speaking speed in Rime is controlled using the `speedAlpha` parameter.
 
 The direction of `speedAlpha` depends on the model:
 
-- **`mist`, `mistv2`:** Lower than 1.0 is faster; higher than 1.0 is slower.
-- **`coda`, `arcana`, `mistv3`:** Higher than 1.0 is faster; lower than 1.0 is slower.
+| Models | Direction |
+| :--- | :--- |
+| `coda`, `arcana`, `mistv3` | Higher than 1.0 is faster; lower than 1.0 is slower. |
+| `mist`, `mistv2` | Lower than 1.0 is faster; higher than 1.0 is slower. |
 
 ```js
 {
@@ -33,8 +36,10 @@ To adjust the speed of individual words or phrases, use the `inlineSpeedAlpha` p
 
 `inlineSpeedAlpha` takes a comma-separated list of speed values applied to words in square brackets. The direction of `inlineSpeedAlpha` depends on the model, matching `speedAlpha`:
 
-- **`mist`, `mistv2`:** Values < 1.0 speed up speech, > 1.0 slow it down.
-- **`coda`, `arcana`, `mistv3`:** Values > 1.0 speed up speech, < 1.0 slow it down.
+| Models | Direction |
+| :--- | :--- |
+| `coda`, `arcana`, `mistv3` | Values > 1.0 speed up speech, < 1.0 slow it down. |
+| `mist`, `mistv2` | Values < 1.0 speed up speech, > 1.0 slow it down. |
 
 For example: “This sentence is [really] [fast]” with inlineSpeedAlpha “0.5, 3” will make “really” slow and “fast” fast on `coda`/`arcana`/`mistv3`, or the reverse on `mist`/`mistv2`.
 

--- a/docs/spell.mdx
+++ b/docs/spell.mdx
@@ -1,7 +1,10 @@
 ---
 title: 'Spell function'
+description: "Force letter-by-letter pronunciation of codes, IDs, and acronyms using the spell() function."
 icon: 'font'
 ---
+
+<Note>The `spell()` function works on Coda, Arcana, and the Mist family.</Note>
 
 ## When to use `spell()`
 
@@ -28,85 +31,119 @@ Let’s see how this works:
 
 ## `spell()` applied to words
 
-If I want the sentence to read:  
+If I want the sentence to read:
 > “The name is spelled J O N, A T H, A N.”
 
-**Input:**  
+**Input:**
 `the name is spelled spell(jonathan).`
 
-```json
-{
-   "speaker": "tibur",
-   "modelId": "mistv3",
-   "text": "the name is spelled spell(jonathan)."
-}
-```
+<audio controls src="https://rime.ai/sounds/docs/jonathan.mp3"></audio>
 
-|  Audio clip  |
-|--------------|
-|  <audio controls src="https://rime.ai/sounds/docs/jonathan.mp3"></audio>
-
-The `spell()` function also works with the `coda` model:
-
-```json
-{
-   "speaker": "astra",
-   "modelId": "coda",
-   "text": "the name is spelled spell(jonathan)."
-}
-```
+<Tabs>
+  <Tab title="Coda">
+    ```json
+    {
+       "speaker": "astra",
+       "modelId": "coda",
+       "text": "the name is spelled spell(jonathan)."
+    }
+    ```
+  </Tab>
+  <Tab title="Arcana">
+    ```json
+    {
+       "speaker": "astra",
+       "modelId": "arcana",
+       "text": "the name is spelled spell(jonathan)."
+    }
+    ```
+  </Tab>
+  <Tab title="Mist v3">
+    ```json
+    {
+       "speaker": "tibur",
+       "modelId": "mistv3",
+       "text": "the name is spelled spell(jonathan)."
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## `spell()` applied to numbers
 
 For number sequences, if I want the sentence to read:
 > “The number is 4 2 5, 2 5 2, 8 9, 2 9.”
 
-**Input:**  
+**Input:**
 ` the number is spell(4252528929).`
 
-```json
-{
-   "speaker": "tibur",
-   "modelId": "mistv3",
-   "text": "the number is spell(4252528929)."
-}
-```
-
-With the `coda` model:
-
-```json
-{
-   "speaker": "astra",
-   "modelId": "coda",
-   "text": "the number is spell(4252528929)."
-}
-```
+<Tabs>
+  <Tab title="Coda">
+    ```json
+    {
+       "speaker": "astra",
+       "modelId": "coda",
+       "text": "the number is spell(4252528929)."
+    }
+    ```
+  </Tab>
+  <Tab title="Arcana">
+    ```json
+    {
+       "speaker": "astra",
+       "modelId": "arcana",
+       "text": "the number is spell(4252528929)."
+    }
+    ```
+  </Tab>
+  <Tab title="Mist v3">
+    ```json
+    {
+       "speaker": "tibur",
+       "modelId": "mistv3",
+       "text": "the number is spell(4252528929)."
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## `spell()` applied to alphanumeric sequences
 
 The same goes for mixed alphanumerics. If I want the sentence to be read:
 > the account is r f, 5 4 3, d c, 2
 
-**Input:**  
+**Input:**
 `the account is spell(rf543dc2).`
 
-```json
-{
-   "speaker": "tibur",
-   "modelId": "mistv3",
-   "text": "the account is spell(rf543dc2)."
-}
-```
-
-With the `coda` model:
-
-```json
-{
-   "speaker": "astra",
-   "modelId": "coda",
-   "text": "the account is spell(rf543dc2)."
-}
-```
+<Tabs>
+  <Tab title="Coda">
+    ```json
+    {
+       "speaker": "astra",
+       "modelId": "coda",
+       "text": "the account is spell(rf543dc2)."
+    }
+    ```
+  </Tab>
+  <Tab title="Arcana">
+    ```json
+    {
+       "speaker": "astra",
+       "modelId": "arcana",
+       "text": "the account is spell(rf543dc2)."
+    }
+    ```
+  </Tab>
+  <Tab title="Mist v3">
+    ```json
+    {
+       "speaker": "tibur",
+       "modelId": "mistv3",
+       "text": "the account is spell(rf543dc2)."
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ## `spell()` applied to typographical symbols
 
@@ -123,22 +160,32 @@ Spell also works with common symbols. For example:
 **Input:**
 `the email address is spell(help@rime.ai).`
 
-```json
-{
-   "speaker": "tibur",
-   "modelId": "mistv3",
-   "text": "the email address is spell(help@rime.ai)."
-}
-```
-
-With the `coda` model:
-
-```json
-{
-   "speaker": "astra",
-   "modelId": "coda",
-   "text": "the email address is spell(help@rime.ai)."
-}
-```
-
-
+<Tabs>
+  <Tab title="Coda">
+    ```json
+    {
+       "speaker": "astra",
+       "modelId": "coda",
+       "text": "the email address is spell(help@rime.ai)."
+    }
+    ```
+  </Tab>
+  <Tab title="Arcana">
+    ```json
+    {
+       "speaker": "astra",
+       "modelId": "arcana",
+       "text": "the email address is spell(help@rime.ai)."
+    }
+    ```
+  </Tab>
+  <Tab title="Mist v3">
+    ```json
+    {
+       "speaker": "tibur",
+       "modelId": "mistv3",
+       "text": "the email address is spell(help@rime.ai)."
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/text-normalization.mdx
+++ b/docs/text-normalization.mdx
@@ -41,7 +41,7 @@ Rime's models may not nail uncommon brand or product names on the first try. Two
 2. **Use custom pronunciations inline** with Rime's phonetic alphabet and `phonemizeBetweenBrackets: true`. See [Custom pronunciation](/docs/custom-pronunciation) for the full reference.
 
 <Warning>
-  `phonemizeBetweenBrackets` works on the Mist family (v1, v2, v3). It does **not** work on Coda or Arcana. For brand or product name pronunciations on Coda or Arcana, submit the word to Rime to add to the dictionary, respell phonetically in plain English (accepting that this is approximate), or use Mist for flows where pronunciation control matters.
+  [`phonemizeBetweenBrackets`](/docs/custom-pronunciation) works on the Mist family (v1, v2, v3). It does **not** work on Coda or Arcana. For brand or product name pronunciations on Coda or Arcana, submit the word to Rime to add to the dictionary, respell phonetically in plain English (accepting that this is approximate), or use Mist for flows where pronunciation control matters.
 </Warning>
 
 For full reference, see [Custom pronunciation](/docs/custom-pronunciation). To check whether a word is already in Rime's dictionary, use the [Coverage API](/api-reference/other/oov).
@@ -53,8 +53,8 @@ For full reference, see [Custom pronunciation](/docs/custom-pronunciation). To c
 | Native text normalization (numbers, currency, dates, etc.) | ✅ | ✅ | ✅ |
 | `spell()` for forced letter-by-letter | ✅ | ✅ | ✅ |
 | Punctuation-driven prosody | ✅ | ✅ | ✅ |
-| `pauseBetweenBrackets` (custom pause tags like `<750>`) | ❌ | ❌ | ✅ |
-| `phonemizeBetweenBrackets` (inline phonetic strings) | ❌ | ❌ | ✅ |
+| [`pauseBetweenBrackets`](/docs/custom-pauses) (custom pause tags like `<750>`) | ❌ | ❌ | ✅ |
+| [`phonemizeBetweenBrackets`](/docs/custom-pronunciation) (inline phonetic strings) | ❌ | ❌ | ✅ |
 | Deterministic per-term pronunciation config | ❌ | ❌ | ✅ |
 
 Coda and Arcana both have parity with Mist for numbers, currency, and abbreviation expansion.

--- a/docs/together-ai.mdx
+++ b/docs/together-ai.mdx
@@ -1,5 +1,6 @@
 ---
 title: Together AI
+description: "Use Rime TTS via Together AI's inference platform."
 ---
 import { IntegrationHeader } from '/snippets/integration-header.mdx'
 

--- a/docs/vapi.mdx
+++ b/docs/vapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: Vapi
+description: "Connect Rime TTS to Vapi voice agents."
 ---
 import { IntegrationHeader } from '/snippets/integration-header.mdx'
 

--- a/docs/videosdk.mdx
+++ b/docs/videosdk.mdx
@@ -1,5 +1,6 @@
 ---
 title: VideoSDK
+description: "Use Rime TTS with VideoSDK."
 ---
 
 import { IntegrationHeader } from "/snippets/integration-header.mdx";

--- a/docs/voices.mdx
+++ b/docs/voices.mdx
@@ -1,20 +1,62 @@
 ---
 title: Voices
+description: "Rime's voice catalog across Coda, Arcana, and Mist — and how to pick a starter voice."
 icon: microphone-lines
 ---
 
 Rime exposes a broad portfolio of production-ready voices across our models. Each voice is designed for real-time conversational performance, with distinct tonal identity, emotional range, and demographic diversity.
 
 As of 19 May 2026, Rime supports the following languages:
-- Arabic `lang=ara` or `lang=ar` (Coda, Arcana)
-- English `lang=eng` or `lang=en`
-- French `lang=fra` or `lang=fr`
-- German `lang=ger` or `lang=de`
-- Hebrew `lang=heb` or `lang=he` (Arcana only)
-- Hindi `lang=hin` or `lang=hi` (Arcana only)
-- Japanese `lang=jpn` or `lang=ja` (Coda, Arcana)
-- Portuguese `lang=por` or `lang=pt` (Coda, Arcana)
-- Spanish `lang=spa` or `lang=es`
+
+| Language | ISO codes | Notes |
+| :--- | :--- | :--- |
+| Arabic | `ara` / `ar` | Coda, Arcana |
+| English | `eng` / `en` | |
+| French | `fra` / `fr` | |
+| German | `ger` / `de` | |
+| Hebrew | `heb` / `he` | Arcana only |
+| Hindi | `hin` / `hi` | Arcana only |
+| Japanese | `jpn` / `ja` | Coda, Arcana |
+| Portuguese | `por` / `pt` | Coda, Arcana |
+| Spanish | `spa` / `es` | |
+
+<Tip>For the live voice list, fetch [`/data/voices/all-v2.json`](/api-reference/data/voices-v2) — it updates as new voices ship.</Tip>
+
+## Accessing Voices
+
+- Online: [/api-reference/data/voices](/api-reference/data/voices)
+- Via API: https://users.rime.ai/data/voices/all-v2.json
+
+Detailed voice metadata is available:
+
+- Online: [/api-reference/data/voice-details](/api-reference/data/voice-details)
+- Via API: https://users.rime.ai/data/voices/voice_details.json
+
+Use the `speaker` parameter in the TTS API to select a voice:
+
+```json
+{
+  "speaker": "astra",
+  "text": "Hello from Rime!",
+  "modelId": "coda",
+  "language": "en"
+}
+```
+
+## Starter voices to try
+
+If you're just getting started, these speakers are confirmed to work across the listed models:
+
+| Speaker | Sounds like | Works on |
+| :--- | :--- | :--- |
+| `astra` | Female, young adult, American Standard | Coda, Arcana, Mist v3, Mist v2 |
+| `luna` | Female, young adult, American | Coda, Arcana, Mist v3 |
+| `celeste` | Female, young adult, American | Coda, Arcana |
+| `orion` | Male, elder, American | Coda, Arcana |
+| `albion` | Male, young adult, English | Coda, Arcana |
+| `cove` | Female, young adult, African American | Mist v3, Mist v2 |
+
+For the complete catalog, fetch [`/data/voices/voice_details.json`](/api-reference/data/voice-details).
 
 ## Coda Voices (Flagship)
 
@@ -62,16 +104,3 @@ Mist voices are:
 - Designed to handle complex proper nouns, brand names, and domain-specific terminology cleanly  
 
 Mist v2 provides a curated set of dependable, production-stable voices that prioritize control and scalability.
-
-## Accessing Voices
-
-- Online: [/api-reference/data/voices](/api-reference/data/voices)
-- Via API: https://users.rime.ai/data/voices/all-v2.json
-
-Detailed voice metadata is available:
-
-- Online: [/api-reference/data/voice-details](/api-reference/data/voice-details)
-- Via API: https://users.rime.ai/data/voices/voice_details.json
-
-Use the `speaker` parameter in the TTS API to select a voice.
-

--- a/docs/websockets-segment.mdx
+++ b/docs/websockets-segment.mdx
@@ -1,5 +1,6 @@
 ---
 title: Segmentation & Behavior Settings
+description: "Control when synthesis fires over the WebSocket API using segment=never, bySentence, and immediate."
 icon: sliders
 ---
 

--- a/docs/websockets.mdx
+++ b/docs/websockets.mdx
@@ -1,5 +1,6 @@
 ---
 title: WebSocket API Overview
+description: "Choose the right Rime WebSocket endpoint: /ws3 (flagship JSON), /ws2 (legacy JSON), or /ws (raw binary)."
 icon: plug
 ---
 

--- a/platform/check-coverage.mdx
+++ b/platform/check-coverage.mdx
@@ -1,5 +1,6 @@
 ---
 title: Check coverage
+description: "Check whether words are in Rime's pronunciation dictionary before they reach end users."
 ---
 
 If you’re new to Rime or have new clients with **unique** words, this is your place to make sure things are perfect out of the gate. 

--- a/platform/speech-qa.mdx
+++ b/platform/speech-qa.mdx
@@ -1,5 +1,6 @@
 ---
 title: Real-time monitoring
+description: "Real-time monitoring and OOV correction for words in your TTS traffic."
 ---
 
 Think of this as your **spell-check for speech**.

--- a/platform/teams.mdx
+++ b/platform/teams.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teams
+description: "Create and manage Rime teams: invites, roles, billing, and member management."
 icon: people-group
 ---
 
@@ -13,11 +14,12 @@ Once you create a team, there is currently no way to undo this action.
 Once you have created a team, and are the owner of that team, you can invite new members.
 Navigate to the **Invite** tab on the dashboard. Enter the email address and desired role for the new team member.
 
-> **Note:** Rime users can only be a member of one team at a time.
+<Note>Rime users can only be a member of one team at a time.</Note>
 
 ## Team billing
 
-⚠️ The Stripe account associated with the Rime user who created the team shall be the billing account for the entire team's api usage.
+<Warning>The Stripe account associated with the Rime user who created the team shall be the billing account for the entire team's api usage.</Warning>
+
 Any owner can access and update the billing information.
 Any API key belonging to a member of the team shall have its usage rolled up into the team's metered usage.
 

--- a/platform/voice-cloning.mdx
+++ b/platform/voice-cloning.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enterprise voice cloning
+description: "Order an enterprise voice clone trained on Coda, Arcana, or Mist."
 icon: clone
 ---
 


### PR DESCRIPTION
## Summary

A sweep of UI/layout/readability improvements across the Documentation tab and a few API reference pages. **Zero factual edits to existing examples** — every new code sample uses speaker + model combinations verified against the live API during this session. Most of the change is callout swaps, decision tables, and metadata additions that benefit both human developers and AI coding agents (especially via `/llms.txt`).

Stacked on top of #221 so the diff here shows only the UI/readability changes.

This is the third in the Coda launch series:
- #221 — main Coda launch docs and doc-accuracy fixes
- #222 — CLI quickstart + CLI reference Coda updates
- #223 — missing-path landing pages and redirects
- **#this** — readability and layout improvements

## What changed

### Component swaps (legacy → Mintlify-native)

Markdown blockquote callouts (`> **Note:**`) replaced with the proper Mintlify components for consistent rendering:

| File | Change |
| :--- | :--- |
| `docs/custom-pauses.mdx` | `> **Note:**` → `<Note>` |
| `docs/custom-pronunciation.mdx` | `> **Note:**` → `<Note>`; promoted Stress from `###` (under Consonants) to its own `##` |
| `platform/teams.mdx` | `> **Note:**` → `<Note>`; `⚠️ ...` paragraph → `<Warning>` |

### New callouts on existing content

These make implicit qualifiers in prose unmissable so readers can skip irrelevant sections immediately:

| File | New callout |
| :--- | :--- |
| `docs/spell.mdx` | Top `<Note>` confirming spell() works on Coda, Arcana, and Mist family |
| `docs/models.mdx` | `<Note>` at top of "Additional controls" naming the Arcana-only params (`temperature`, `top_p`, `repetition_penalty`) |
| `docs/quickstart-five-minute.mdx` | `<Note>` at top of "Custom pronunciation" flagging it as Mist-only |
| `docs/voices.mdx` | `<Tip>` after the language table linking to the live JSON |

### Tabs and tables (Coda-first ordering)

- `docs/spell.mdx`: each of the 4 example sections converted to `<Tabs>` (Coda → Arcana → Mist v3) so users see model variants side-by-side instead of stacked
- `docs/speed.mdx`: per-model direction lists (`speedAlpha`, `inlineSpeedAlpha`) converted to 2-column tables, Coda/Arcana/Mist v3 row listed first
- `docs/voices.mdx`: 9-line language bullet list converted to a 3-column table

### Heading hierarchy fixes

- `docs/models.mdx`: flattened `## Mist` (which contained Mist v3 + Mist v2 + legacy Mist as bolded sub-paragraphs) into three top-level `##` sections — now consistent with `## Coda` and `## Arcana` siblings. Anchors and scrollspy work cleanly for each model.

### Decision-helpers (new high-impact additions)

- `docs/models.mdx`: new `## Which model should I use?` table at the top — 4 rows mapping use case to model so users don't have to read every section
- `docs/voices.mdx`: new `## Starter voices to try` table with 6 confirmed-working speakers, demographics taken from the live `voice_details.json`, model support verified by API tests earlier in the session
- `docs/voices.mdx`: "Accessing Voices" section moved up to right after the language table (was buried at the bottom)

### Worked code examples on pages that had none

- `docs/introduction.mdx`: new `## Hello from Coda in 30 seconds` curl block — full working request with `Authorization: Bearer YOUR_API_KEY` so agents and skimmers see the canonical request shape immediately
- `docs/introduction.mdx`: "What Makes Coda Different" 4 bullets → `<CardGroup cols={2}>` with icons (bolt / globe / clock / server)
- `docs/voices.mdx`: JSON `speaker` example so readers see the parameter shape, not just a description
- `docs/latency.mdx`: Python streaming-consumption example added after the curl, showing `requests.post(..., stream=True)` + `iter_content`

### Response-shape examples for API reference

- `api-reference/other/oov.mdx`: new `<ResponseExample>` block with two real responses (array of OOV words, empty array when all covered)
- `api-reference/other/textnorm.mdx`: new `<ResponseExample>` block with the actual normalized-text response

### Common errors documentation

- `docs/api-authentication.mdx`: new `## Common auth errors` table with the actual 401 responses captured from the live API (`missing headers`, `invalid api key`), plus a clarification that the token alone without `Bearer` is rejected

### Privacy/compliance restructure

- `docs/privacy-compliance.mdx`: SOC 2 + HIPAA certifications lifted into a 2-column `<CardGroup>` with shield-check icons; added `## Certifications` and `## Data handling` headings to break up 5 paragraphs of plain prose

### Other touch-ups

- `docs/linguistics.mdx`: fixed broken nav reference ("Customizing Speech folder" → "Customizing Mist group" — matches the actual nav group)
- `docs/models.mdx`: cleaned `&lt;1` / `&gt;1` HTML entities to `` `<1` `` / `` `>1` `` in backticks

### Metadata sweep (D)

**`description:` frontmatter added on 61 pages** that didn't have one. This is the single biggest improvement for AI coding agents — Mintlify auto-generates `/llms.txt` and `/llms-full.txt` from frontmatter, so every doc now has a curated one-line summary in the manifest agents fetch. Also improves search snippets and OpenGraph cards for human users.

### Cross-links (G)

Parameter mentions in prose now link to their canonical documentation page:

- `phonemizeBetweenBrackets` → `/docs/custom-pronunciation`
- `pauseBetweenBrackets` → `/docs/custom-pauses`
- `noTextNormalization` → `/docs/text-normalization`
- `speedAlpha` → `/docs/speed`

Applied on 5 high-traffic pages (`docs/punctuation.mdx`, `docs/text-normalization.mdx`, `docs/latency.mdx`, `docs/models.mdx`, `docs/quickstart-five-minute.mdx`). Self-references on canonical pages and historical changelog entries were skipped.

### Terminology consistency (I)

- `Mistv2` → `Mist v2` in prose on 3 pages (`docs/models.mdx`, `docs/introduction.mdx`, `docs/on-prem/quickstart.mdx`). API values like `modelId: mistv2` left alone.

## Out of scope

- **Last-updated timestamps (K)**: Mintlify doesn't support per-page `updatedAt:` frontmatter — adding it would be cruft Mintlify ignores. The right fix is a docs.json config option to enable git-history-based timestamps, which is a separate decision.
- **`websocket` capitalization sweep**: lowercase mentions are all in code (`import websockets`, `websockets.connect`), URL paths, or historical changelog entries — all should stay as-is. Prose already uses "WebSocket" correctly.
- **Integration pages and on-prem detail pages**: only got frontmatter descriptions; deeper restructure deferred to separate PRs per earlier guidance.

## Verification

Every new code example uses verified-working combinations:

- `astra` + `coda` + `language: en` — 200 audio/mp3 (confirmed earlier in session)
- `astra` + `arcana` + `language: en` — works (spell() also confirmed)
- `tibur` + `mistv3` — works (existing example pattern preserved)
- `cove` + `mistv3` — works (existing pattern preserved)
- Auth errors captured live: `401 missing headers` (no Authorization header), `401 invalid api key` (bad token or no Bearer scheme)
- `/oov` and `/textnorm` response shapes captured live

## Test plan

- [ ] Open local Mintlify preview and confirm the new decision tables, starter-voices table, CardGroup, and Tabs render as intended
- [ ] Spot-check `/llms.txt` after deploy to confirm new descriptions appear
- [ ] Verify links work: `phonemizeBetweenBrackets` link from `docs/text-normalization.mdx`, etc.
- [ ] Confirm `docs/models.mdx` heading anchors work for `#mist-v3`, `#mist-v2`, `#mist-legacy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)