### PR TITLE
Simplify introduction page description

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: "Get started with Rime's TTS API — Coda flagship, multilingual support, real-time conversational latency."
+description: "Get started with Rime's TTS API"
 icon: book
 ---
 


### PR DESCRIPTION
## Summary
- Shortens the `description` frontmatter in `docs/introduction.mdx` to just "Get started with Rime's TTS API".

## Test plan
- [ ] Verify the updated description renders correctly on the introduction page in Mintlify preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)