### PR TITLE
Fix broken intra-doc anchor links

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -160,7 +160,7 @@ icon: list
 
 <Update label="2025-12-06">
 * Arcana release `20251206`:
-  * [OpenTelemetry metrics](/docs/on-prem/metrics#metrics-arcana) are now available in the model images.
+  * [OpenTelemetry metrics](/docs/on-prem/metrics#opentelemetry-metrics) are now available in the model images.
   * Quality and performance improvements.
 </Update>
 

--- a/docs/daily.mdx
+++ b/docs/daily.mdx
@@ -67,7 +67,7 @@ cd rime-pipecat-agent
 
 ### 2.2 Set up environment variables
 
-In the new directory, create a file called `.env` and add the keys that you gathered in [Step 1](#step-1-prerequisites):
+In the new directory, create a file called `.env` and add the keys that you gathered in [Step 1](#step-1%3A-prerequisites):
 
 ```
 RIME_API_KEY=your_rime_api_key

--- a/docs/pre-normalization.mdx
+++ b/docs/pre-normalization.mdx
@@ -4,7 +4,7 @@ description: "Optional patterns you can pre-expand in your application before se
 ---
 
 <Warning>
-  **Most applications shouldn't pre-normalize.** Rime handles common patterns — currency with symbols, dates with years, clock times, phone numbers, standard measurements, and most numeric formats — natively. Pre-normalizing adds latency and engineering complexity for behavior you usually get for free. Before adding a pre-processing layer, review the [formats Rime handles natively](/docs/text-normalization#whats-handled-at-a-glance) and verify any specific input with the [`/textnorm` endpoint](/docs/text-normalization#debugging-with-the-textnorm-endpoint).
+  **Most applications shouldn't pre-normalize.** Rime handles common patterns — currency with symbols, dates with years, clock times, phone numbers, standard measurements, and most numeric formats — natively. Pre-normalizing adds latency and engineering complexity for behavior you usually get for free. Before adding a pre-processing layer, review the [formats Rime handles natively](/docs/text-normalization#handled-at-a-glance) and verify any specific input with the [`/textnorm` endpoint](/docs/text-normalization#debugging-with-the-textnorm-endpoint).
 </Warning>
 
 If you've reviewed the native handling and still need to pre-normalize specific patterns, this page documents the known gaps and provides a prompt template you can drop into the layer that generates your text.

--- a/docs/quickstart-livekit.mdx
+++ b/docs/quickstart-livekit.mdx
@@ -75,7 +75,7 @@ cd rime-voice-agent
 
 ### 2.2 Set up environment variables
 
-In the new directory, create a file called `.env` and add the keys that you created in [Step 1](#step-1:-prerequisites):
+In the new directory, create a file called `.env` and add the keys that you created in [Step 1](#step-1%3A-prerequisites):
 
 ```
 LIVEKIT_URL=wss://your-project.livekit.cloud

--- a/docs/text-normalization.mdx
+++ b/docs/text-normalization.mdx
@@ -9,7 +9,7 @@ When you send text to Rime's TTS models, a normalization layer runs first. It ex
   **Rime handles text normalization automatically.** Most common formats — currency with symbols, dates with years, clock times, phone numbers, and standard measurements — expand correctly without any preprocessing. Just write naturally. If something sounds wrong, [debug it with `/textnorm`](#debugging-with-the-textnorm-endpoint) before adding a pre-processing layer to your application.
 </Note>
 
-## What's handled, at a glance
+## Handled at a glance
 
 Click any category for the full input/output reference.
 

--- a/docs/voices.mdx
+++ b/docs/voices.mdx
@@ -6,6 +6,8 @@ icon: microphone-lines
 
 Rime exposes a broad portfolio of production-ready voices across our models. Each voice is designed for real-time conversational performance, with distinct tonal identity, emotional range, and demographic diversity.
 
+## Languages
+
 As of 19 May 2026, Rime supports the following languages:
 
 | Language | ISO codes | Notes |


### PR DESCRIPTION
## Summary
- Added a `## Languages` heading on `docs/voices.mdx` so the existing inbound link to `/docs/voices#languages` (from the Coda landing page) resolves.
- Fixed the `Step 1: Prerequisites` anchors in the LiveKit and Pipecat quickstarts. Mintlify URL-encodes the colon, so the correct fragment is `#step-1%3A-prerequisites`.
- Repointed the 2025-12-06 Arcana changelog entry from the nonexistent `#metrics-arcana` to the existing `#opentelemetry-metrics` anchor.
- Renamed the text-normalization page's `What's handled, at a glance` heading to `Handled at a glance` so it produces a clean slug. Mintlify's smartypants was converting the straight apostrophe to a curly one in the rendered HTML, which then URL-encoded to `%E2%80%99` in the slug and broke the inbound link from the pre-normalization warning. The inbound link was updated to `#handled-at-a-glance`.

All anchors were verified end-to-end against `mintlify dev`.

## Test plan
- [ ] `/docs/voices#languages` (from the Coda doc) scrolls to the languages table
- [ ] `Step 1` cross-references in `/docs/quickstart-livekit` and `/docs/daily` scroll to the prerequisites section
- [ ] The 2025-12-06 Arcana changelog `OpenTelemetry metrics` link scrolls to the OTel section under the Arcana container
- [ ] The pre-normalization warning's `formats Rime handles natively` link scrolls to `Handled at a glance` on the text-normalization page

🤖 Generated with [Claude Code](https://claude.com/claude-code)