### PR TITLE
Add coda to on-prem quickstart

### DIFF
--- a/docs/on-prem/quickstart.mdx
+++ b/docs/on-prem/quickstart.mdx
@@ -156,6 +156,13 @@ For Arcana only, you can also load the engine and data packages from different c
 * `us-docker.pkg.dev/rime-labs/engine/arcana:<tag>`
 * `us-docker.pkg.dev/rime-labs/package/arcana/<language>:<tag>`
 
+#### Coda (multilingual)
+
+The Coda v1 images can be found at `us-docker.pkg.dev/rime-labs/coda/v1/coda:<tag>`.
+
+* The support languages are: `en`, `es`, `fr`, `pt`, `de`, `ja`.
+* The latest version is `20260517`.
+
 #### Mist v3 (multilingual)
 
 The Mist v3 images can be found at `us-docker.pkg.dev/rime-labs/mist/v3/omni:<tag>`


### PR DESCRIPTION
Not advertising ar (which is also a part of coda package) and hi (which is only a part of telnyx package)