### PR TITLE
Document RFC-canonical audio MIME types; deprecate legacy aliases

### DIFF
--- a/api-reference/arcana/http.mdx
+++ b/api-reference/arcana/http.mdx
@@ -15,10 +15,20 @@ Set the `Accept` header to one of the following values:
 |---|---|---|
 | Opus (WebM) | `audio/webm;codecs=opus` | Recommended. Opus offers excellent compression. WebM streams natively in browsers. |
 | Opus (OGG) | `audio/ogg;codecs=opus` | Opus offers excellent compression. OGG container. |
-| MP3 | `audio/mp3` | Lower compression rate than Opus. Highest compatibility across devices and players. |
+| MP3 | `audio/mpeg` | Lower compression rate than Opus. Highest compatibility across devices and players. |
 | WAV | `audio/wav` | Uncompressed. RIFF WAVE header with 16-bit little-endian linear PCM samples. Streams natively in browsers. |
-| PCM | `audio/pcm` | Headerless 16-bit little-endian linear PCM. |
-| G.711 μ-law | `audio/x-mulaw` | Headerless stream of audio bytes. |
+| PCM | `audio/L16` | Headerless 16-bit little-endian linear PCM. |
+| G.711 μ-law | `audio/PCMU` | Headerless stream of audio bytes. |
+
+### Deprecated aliases
+
+Still accepted for backwards compatibility; new code should use the RFC types above.
+
+| Deprecated | Use instead |
+|---|---|
+| `audio/mp3` | `audio/mpeg` |
+| `audio/pcm` | `audio/L16` |
+| `audio/x-mulaw` | `audio/PCMU` |
 
 ## Variable Parameters
 

--- a/api-reference/coda/http.mdx
+++ b/api-reference/coda/http.mdx
@@ -15,10 +15,20 @@ Set the `Accept` header to one of the following values:
 |---|---|---|
 | Opus (WebM) | `audio/webm;codecs=opus` | Recommended. Opus offers excellent compression. WebM streams natively in browsers. |
 | Opus (OGG) | `audio/ogg;codecs=opus` | Opus offers excellent compression. OGG container. |
-| MP3 | `audio/mp3` | Lower compression rate than Opus. Highest compatibility across devices and players. |
+| MP3 | `audio/mpeg` | Lower compression rate than Opus. Highest compatibility across devices and players. |
 | WAV | `audio/wav` | Uncompressed. RIFF WAVE header with 16-bit little-endian linear PCM samples. Streams natively in browsers. |
-| PCM | `audio/pcm` | Headerless 16-bit little-endian linear PCM. |
-| G.711 μ-law | `audio/x-mulaw` | Headerless stream of audio bytes. |
+| PCM | `audio/L16` | Headerless 16-bit little-endian linear PCM. |
+| G.711 μ-law | `audio/PCMU` | Headerless stream of audio bytes. |
+
+### Deprecated aliases
+
+Still accepted for backwards compatibility; new code should use the RFC types above.
+
+| Deprecated | Use instead |
+|---|---|
+| `audio/mp3` | `audio/mpeg` |
+| `audio/pcm` | `audio/L16` |
+| `audio/x-mulaw` | `audio/PCMU` |
 
 ## Variable Parameters
 

--- a/api-reference/mistv2/http.mdx
+++ b/api-reference/mistv2/http.mdx
@@ -13,9 +13,19 @@ Set the `Accept` header to one of the following values:
 
 | Format | Accept Header | Default Sampling Rate | Notes |
 |---|---|---|---|
-| MP3 | `audio/mp3` | 22050 | |
-| PCM | `audio/pcm` | 16000 | Headerless 16-bit little-endian linear PCM. |
-| G.711 μ-law | `audio/x-mulaw` | 8000 | Headerless stream of audio bytes. |
+| MP3 | `audio/mpeg` | 22050 | |
+| PCM | `audio/L16` | 16000 | Headerless 16-bit little-endian linear PCM. |
+| G.711 μ-law | `audio/PCMU` | 8000 | Headerless stream of audio bytes. |
+
+### Deprecated aliases
+
+Still accepted for backwards compatibility; new code should use the RFC types above.
+
+| Deprecated | Use instead |
+|---|---|
+| `audio/mp3` | `audio/mpeg` |
+| `audio/pcm` | `audio/L16` |
+| `audio/x-mulaw` | `audio/PCMU` |
 
 ## Variable Parameters
 
@@ -73,7 +83,7 @@ Set the `Accept` header to one of the following values:
 ```bash cURL
 curl --request POST \
   --url https://users.rime.ai/v1/rime-tts \
-  --header 'Accept: audio/mp3' \
+  --header 'Accept: audio/mpeg' \
   --header 'Authorization: Bearer YOUR_API_KEY' \
   --header 'Content-Type: application/json' \
   --output output.mp3 \
@@ -102,7 +112,7 @@ payload = {
     "speedAlpha": 1.0
 }
 headers = {
-    "Accept": "audio/mp3",
+    "Accept": "audio/mpeg",
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
 }
@@ -119,7 +129,7 @@ with requests.post(url, headers=headers, json=payload, stream=True) as response:
 const options = {
   method: 'POST',
   headers: {
-    Accept: 'audio/mp3',
+    Accept: 'audio/mpeg',
     Authorization: 'Bearer YOUR_API_KEY',
     'Content-Type': 'application/json'
   },
@@ -150,7 +160,7 @@ curl_setopt_array($curl, [
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "{\n  \"speaker\": \"astra\",\n  \"text\": \"Hello from Rime!\",\n  \"modelId\": \"mistv2\",\n  \"lang\": \"eng\",\n  \"samplingRate\": 22050,\n  \"speedAlpha\": 1.0\n}",
   CURLOPT_HTTPHEADER => [
-    "Accept: audio/mp3",
+    "Accept: audio/mpeg",
     "Authorization: Bearer YOUR_API_KEY",
     "Content-Type: application/json"
   ],
@@ -186,7 +196,7 @@ func main() {
 
   req, _ := http.NewRequest("POST", url, payload)
 
-  req.Header.Add("Accept", "audio/mp3")
+  req.Header.Add("Accept", "audio/mpeg")
   req.Header.Add("Authorization", "Bearer YOUR_API_KEY")
   req.Header.Add("Content-Type", "application/json")
 
@@ -201,7 +211,7 @@ func main() {
 
 ```java Java
 HttpResponse<String> response = Unirest.post("https://users.rime.ai/v1/rime-tts")
-  .header("Accept", "audio/mp3")
+  .header("Accept", "audio/mpeg")
   .header("Authorization", "Bearer YOUR_API_KEY")
   .header("Content-Type", "application/json")
   .body("{\n  \"speaker\": \"astra\",\n  \"text\": \"Hello from Rime!\",\n  \"modelId\": \"mistv2\",\n  \"lang\": \"eng\",\n  \"samplingRate\": 22050,\n  \"speedAlpha\": 1.0\n}")

--- a/api-reference/mistv3/http.mdx
+++ b/api-reference/mistv3/http.mdx
@@ -15,10 +15,20 @@ Set the `Accept` header to one of the following values:
 |---|---|---|
 | Opus (WebM) | `audio/webm;codecs=opus` | Recommended. Opus offers excellent compression. WebM streams natively in browsers. |
 | Opus (OGG) | `audio/ogg;codecs=opus` | Opus offers excellent compression. OGG container. |
-| MP3 | `audio/mp3` | Lower compression rate than Opus. Highest compatibility across devices and players. |
+| MP3 | `audio/mpeg` | Lower compression rate than Opus. Highest compatibility across devices and players. |
 | WAV | `audio/wav` | Uncompressed. RIFF WAVE header with 16-bit little-endian linear PCM samples. Streams natively in browsers. |
-| PCM | `audio/pcm` | Headerless 16-bit little-endian linear PCM. |
-| G.711 μ-law | `audio/x-mulaw` | Headerless stream of audio bytes. |
+| PCM | `audio/L16` | Headerless 16-bit little-endian linear PCM. |
+| G.711 μ-law | `audio/PCMU` | Headerless stream of audio bytes. |
+
+### Deprecated aliases
+
+Still accepted for backwards compatibility; new code should use the RFC types above.
+
+| Deprecated | Use instead |
+|---|---|
+| `audio/mp3` | `audio/mpeg` |
+| `audio/pcm` | `audio/L16` |
+| `audio/x-mulaw` | `audio/PCMU` |
 
 ## Variable Parameters
 

--- a/docs/api-authentication.mdx
+++ b/docs/api-authentication.mdx
@@ -21,7 +21,7 @@ curl --request POST \
   --url https://users.rime.ai/v1/rime-tts \
   --header 'Authorization: Bearer YOUR_API_KEY' \
   --header 'Content-Type: application/json' \
-  --header 'Accept: audio/mp3' \
+  --header 'Accept: audio/mpeg' \
   --data '{"speaker":"astra","text":"hello","modelId":"coda","language":"en"}'
 ```
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -17,7 +17,7 @@ curl --request POST \
   --url https://users.rime.ai/v1/rime-tts \
   --header 'Authorization: Bearer YOUR_API_KEY' \
   --header 'Content-Type: application/json' \
-  --header 'Accept: audio/mp3' \
+  --header 'Accept: audio/mpeg' \
   --output hello.mp3 \
   --data '{
     "speaker": "astra",

--- a/docs/latency.mdx
+++ b/docs/latency.mdx
@@ -50,7 +50,7 @@ The image above contains a plot of both response time and TTFB for the following
 
 ```bash
 curl -X POST http://users.rime.ai/v1/rime-tts \
-  -H 'Accept: audio/pcm' \
+  -H 'Accept: audio/L16' \
   -H 'Authorization: Bearer $RIME_API_KEY' \
   -d '{"text": "I love the book that she gave me. And I was so happy that she gave it to me.", "speaker": "cove",  "modelId": "mistv3"}'
 ```
@@ -65,7 +65,7 @@ with requests.post(
     headers={
         "Authorization": f"Bearer {RIME_API_KEY}",
         "Content-Type": "application/json",
-        "Accept": "audio/mp3",
+        "Accept": "audio/mpeg",
     },
     json={
         "speaker": "astra",

--- a/docs/on-prem/quickstart.mdx
+++ b/docs/on-prem/quickstart.mdx
@@ -385,7 +385,7 @@ Sample response file: [`result.txt`](https://drive.google.com/file/d/1GW2D8pm5wi
 **Request:**
 
 ```bash Request example
-curl -X POST "http://localhost:8000" -H "Authorization: Bearer <API KEY>" -H "Content-Type: application/json" -H "Accept: audio/mp3" -d '{
+curl -X POST "http://localhost:8000" -H "Authorization: Bearer <API KEY>" -H "Content-Type: application/json" -H "Accept: audio/mpeg" -d '{
   "text": "I would love to have a conversation with you.",
   "speaker": "joy",
   "modelId": "mist"
@@ -401,7 +401,7 @@ Sample response file: [`result.mp3`](https://drive.google.com/file/d/1iwmWB1byBX
 **Request:**
 
 ```bash Request example
-curl -X POST "http://localhost:8000" -H "Authorization: Bearer <API KEY>" -H "Content-Type: application/json" -H "Accept: audio/pcm" -d '{
+curl -X POST "http://localhost:8000" -H "Authorization: Bearer <API KEY>" -H "Content-Type: application/json" -H "Accept: audio/L16" -d '{
   "text": "I would love to have a conversation with you.",
   "speaker": "joy",
   "modelId": "mist"

--- a/docs/openclaw.mdx
+++ b/docs/openclaw.mdx
@@ -179,7 +179,7 @@ def synthesize(text, voice, speed, lang, api_key, model="arcana"):
         data=json.dumps(body).encode(),
         headers={
             "Authorization": f"Bearer {api_key}",
-            "Accept": "audio/pcm",
+            "Accept": "audio/L16",
             "Content-Type": "application/json",
         },
         method="POST",

--- a/platform/speech-qa.mdx
+++ b/platform/speech-qa.mdx
@@ -45,7 +45,7 @@ For example, sending the request
 curl --request POST \
   --url https://users.rime.ai/v1/rime-tts \
   --header 'Authorization: Bearer YOUR_API_KEY' \
-  --header 'Accept: audio/mp3' \
+  --header 'Accept: audio/mpeg' \
   --header 'Content-Type: application/json' \
   --output speech_with_oov.mp3 \
   --fail \

--- a/platform/voice-cloning.mdx
+++ b/platform/voice-cloning.mdx
@@ -40,7 +40,7 @@ Rime offers high-quality enterprise voice cloning for customers on our Growth an
     ```bash
     curl --request POST \
         --url https://users.rime.ai/v1/rime-tts \
-        --header 'Accept: audio/pcm' \
+        --header 'Accept: audio/L16' \
         --header 'Authorization: Bearer YOUR_API_KEY' \
         --header 'Content-Type: application/json' \
         --data '{


### PR DESCRIPTION
## Summary

- Primary Audio Formats tables on the HTTP reference pages (arcana, coda, mist v2, mist v3) now advertise the RFC-canonical MIME types: `audio/mpeg`, `audio/L16`, `audio/PCMU`.
- Each HTTP reference page gains a "Deprecated aliases" subsection mapping the legacy types (`audio/mp3`, `audio/pcm`, `audio/x-mulaw`) to their replacements. Legacy types remain accepted by the API for backwards compatibility.
- Updated curl / JS / Python `Accept`-header examples across the docs (introduction, api-authentication, latency, on-prem quickstart, openclaw, speech-qa, voice-cloning) to use the canonical types.

Companion API changes: rimelabs/rime — `audio/L16` and `audio/PCMU` are now accepted (commit `26af57bd`).

Linear: [ENG-506](https://linear.app/rime/issue/ENG-506/onprem-api-image-improvement-requests)

## Test plan

- [x] `mintlify dev` and visually confirm each updated page renders correctly (tables + deprecated subsections).
- [ ] Spot-check that the curl examples on the introduction / api-authentication pages still copy-paste-execute against `users.rime.ai`.