### PR TITLE
textnorm: document language parameter

### DIFF
--- a/api-reference/other/textnorm.mdx
+++ b/api-reference/other/textnorm.mdx
@@ -48,7 +48,9 @@ curl -X POST https://optimize.rime.ai/textnorm \
 </ParamField>
 
 <ParamField body="lang" type="string">
-  Language code (e.g. `en`, `es`, `fr`, `de`, and [additional languages](/api-reference/data/voices-v2#languages)) selecting the normalization rules. Defaults to English when omitted. Also accepts the alias `language`.
+  Language code (e.g. `en`, `es`, `fr`, `de`, and [additional languages](/api-reference/data/voices-v2#languages)) selecting the normalization rules. Defaults to English when omitted.
+
+  Also accepts the alias `language`.
 </ParamField>
 
 <RequestExample>

--- a/api-reference/other/textnorm.mdx
+++ b/api-reference/other/textnorm.mdx
@@ -12,12 +12,12 @@ This API endpoint returns the normalized form of an input string — the way Rim
 Use it to preview how a given input will be spoken, or to debug unexpected pronunciations of digits, sequences, and punctuation.
 
 <Note>
-  This endpoint covers Rime's English text normalization. For details on what's normalized natively, known gaps, and how to pre-normalize problematic patterns, see [Text normalization](/docs/text-normalization).
+  Defaults to English. Pass the `lang` field (ISO 639 subtag) for other languages. For details on what's normalized natively, known gaps, and how to pre-normalize problematic patterns, see [Text normalization](/docs/text-normalization).
 </Note>
 
 ## Example
 
-A request takes only the string `text`, for example:
+A request takes the string `text` and, optionally, a `lang` subtag:
 
 ```bash
 curl -X POST https://optimize.rime.ai/textnorm \
@@ -32,10 +32,23 @@ The response includes the normalized string:
 {"normalized":"one two three four, one , two , three , four, one, eight hundred, four four four, four one four one"}
 ```
 
+To normalize text in a non-English language, pass an ISO 639 language subtag:
+
+```bash
+curl -X POST https://optimize.rime.ai/textnorm \
+     -H "Authorization: Bearer $(rime key)" \
+     -H "Content-Type: application/json" \
+     -d '{"text":"Tengo 2 perros","lang":"es"}'
+```
+
 ## Variable Parameters
 
 <ParamField body="text" type="string" required>
   The string you'd like to normalize. Numbers, phone numbers, and other non-standard words will be expanded into their spoken form.
+</ParamField>
+
+<ParamField body="lang" type="string">
+  ISO 639 language subtag (e.g. `en`, `es`, `fr`, `de`) selecting the normalization rules. Defaults to English when omitted.
 </ParamField>
 
 <RequestExample>

--- a/api-reference/other/textnorm.mdx
+++ b/api-reference/other/textnorm.mdx
@@ -12,7 +12,7 @@ This API endpoint returns the normalized form of an input string — the way Rim
 Use it to preview how a given input will be spoken, or to debug unexpected pronunciations of digits, sequences, and punctuation.
 
 <Note>
-  Defaults to English. Pass the `lang` field (ISO 639 subtag) for other languages. For details on what's normalized natively, known gaps, and how to pre-normalize problematic patterns, see [Text normalization](/docs/text-normalization).
+  Defaults to English. Pass the `lang` field (ISO 639 subtag) for other languages — see [Languages](/api-reference/data/voices-v2#languages) for the full list. For details on what's normalized natively, known gaps, and how to pre-normalize problematic patterns, see [Text normalization](/docs/text-normalization).
 </Note>
 
 ## Example
@@ -48,7 +48,7 @@ curl -X POST https://optimize.rime.ai/textnorm \
 </ParamField>
 
 <ParamField body="lang" type="string">
-  ISO 639 language subtag (e.g. `en`, `es`, `fr`, `de`) selecting the normalization rules. Defaults to English when omitted.
+  ISO 639 language subtag (e.g. `en`, `es`, `fr`, `de`, and [additional languages](/api-reference/data/voices-v2#languages)) selecting the normalization rules. Defaults to English when omitted. Also accepts the alias `language`.
 </ParamField>
 
 <RequestExample>

--- a/api-reference/other/textnorm.mdx
+++ b/api-reference/other/textnorm.mdx
@@ -12,12 +12,12 @@ This API endpoint returns the normalized form of an input string — the way Rim
 Use it to preview how a given input will be spoken, or to debug unexpected pronunciations of digits, sequences, and punctuation.
 
 <Note>
-  Defaults to English. Pass the `lang` field (ISO 639 subtag) for other languages — see [Languages](/api-reference/data/voices-v2#languages) for the full list. For details on what's normalized natively, known gaps, and how to pre-normalize problematic patterns, see [Text normalization](/docs/text-normalization).
+  Defaults to English. Pass the `lang` field for other languages — see [Languages](/api-reference/data/voices-v2#languages) for the full list. For details on what's normalized natively, known gaps, and how to pre-normalize problematic patterns, see [Text normalization](/docs/text-normalization).
 </Note>
 
 ## Example
 
-A request takes the string `text` and, optionally, a `lang` subtag:
+A request takes the string `text` and, optionally, a `lang` code:
 
 ```bash
 curl -X POST https://optimize.rime.ai/textnorm \
@@ -32,7 +32,7 @@ The response includes the normalized string:
 {"normalized":"one two three four, one , two , three , four, one, eight hundred, four four four, four one four one"}
 ```
 
-To normalize text in a non-English language, pass an ISO 639 language subtag:
+To normalize text in a non-English language, pass a language code:
 
 ```bash
 curl -X POST https://optimize.rime.ai/textnorm \
@@ -48,7 +48,7 @@ curl -X POST https://optimize.rime.ai/textnorm \
 </ParamField>
 
 <ParamField body="lang" type="string">
-  ISO 639 language subtag (e.g. `en`, `es`, `fr`, `de`, and [additional languages](/api-reference/data/voices-v2#languages)) selecting the normalization rules. Defaults to English when omitted. Also accepts the alias `language`.
+  Language code (e.g. `en`, `es`, `fr`, `de`, and [additional languages](/api-reference/data/voices-v2#languages)) selecting the normalization rules. Defaults to English when omitted. Also accepts the alias `language`.
 </ParamField>
 
 <RequestExample>

--- a/docs/text-normalization.mdx
+++ b/docs/text-normalization.mdx
@@ -78,7 +78,7 @@ curl -X POST https://optimize.rime.ai/textnorm \
 {"normalized":"one two three four, one , two , three , four, one, eight hundred, four four four, four one four one"}
 ```
 
-The endpoint defaults to English. For other languages, pass an ISO 639 language subtag in the `lang` field:
+The endpoint defaults to English. For other languages, pass a language code in the `lang` field:
 
 ```bash
 curl -X POST https://optimize.rime.ai/textnorm \

--- a/docs/text-normalization.mdx
+++ b/docs/text-normalization.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Text normalization'
-description: "Rime automatically normalizes English text — numbers, dates, currency, phone numbers, measurements, and more — before synthesis."
+description: "Rime automatically normalizes text — numbers, dates, currency, phone numbers, measurements, and more — before synthesis."
 ---
 
 When you send text to Rime's TTS models, a normalization layer runs first. It expands numbers, dates, currency, phone numbers, measurements, and other non-standard words into their spoken form before the model synthesizes audio.
@@ -87,7 +87,7 @@ curl -X POST https://optimize.rime.ai/textnorm \
     -d '{"text":"Tengo 2 perros","lang":"es"}'
 ```
 
-Output is the same regardless of which model you'll synthesize with. For the full request and response reference, see the [Text Normalization API](/api-reference/other/textnorm).
+See [Languages](/docs/voices#languages) for the full list of supported languages. Output is the same regardless of which model you'll synthesize with. For the full request and response reference, see the [Text Normalization API](/api-reference/other/textnorm).
 
 ### Triage workflow
 

--- a/docs/text-normalization.mdx
+++ b/docs/text-normalization.mdx
@@ -78,7 +78,16 @@ curl -X POST https://optimize.rime.ai/textnorm \
 {"normalized":"one two three four, one , two , three , four, one, eight hundred, four four four, four one four one"}
 ```
 
-This endpoint covers Rime's English text normalization. Output is the same regardless of which model you'll synthesize with. For the full request and response reference, see the [Text Normalization API](/api-reference/other/textnorm).
+The endpoint defaults to English. For other languages, pass an ISO 639 language subtag in the `lang` field:
+
+```bash
+curl -X POST https://optimize.rime.ai/textnorm \
+    -H "Authorization: Bearer $(rime key)" \
+    -H "Content-Type: application/json" \
+    -d '{"text":"Tengo 2 perros","lang":"es"}'
+```
+
+Output is the same regardless of which model you'll synthesize with. For the full request and response reference, see the [Text Normalization API](/api-reference/other/textnorm).
 
 ### Triage workflow
 


### PR DESCRIPTION
Per https://github.com/rimelabs/rime/pull/944, we're adding a `lang` param to theAPI  `/textnorm` endpoint. The engine's endpoint already accepts the param and is i.e. already multilingual, so once the API endpoint passes `lang` through, the API will be multilingual.

Updating the docs to reflect that.

Leaving this as a draft for now because this should wait to merge until the linked PR is deployed.